### PR TITLE
Try another item representation and fix some CI stuff

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,8 @@ on:
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
+  RUSTDOCFLAGS: "-Dwarnings"
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   check:
@@ -43,3 +45,5 @@ jobs:
       run: cargo clippy
     - name: Cargo fmt
       run: cargo fmt --check
+    - name: Cargo doc
+      run: cargo doc

--- a/linter_api/src/ast/item.rs
+++ b/linter_api/src/ast/item.rs
@@ -30,7 +30,7 @@ impl ItemId {
 
 pub trait ItemData<'ast>: Debug {
     /// Returns the [`ItemId`] of this item. This is a unique identifier used for comparison
-    /// and to request items from the [`Context`][`crate::context::Context`].
+    /// and to request items from the [`AstContext`][`crate::context::AstContext`].
     fn get_id(&self) -> ItemId;
 
     /// The [`Span`] of the entire item. This span should be used for general item related
@@ -214,7 +214,7 @@ pub trait ConstItem<'ast>: ItemData<'ast> {
 
     /// The [`BodyId`] of the initialization body.
     ///
-    /// This can return `None` for [`ConstItemItem`]s asscociated with a trait. For
+    /// This can return `None` for [`ConstItem`]s asscociated with a trait. For
     /// normal items this will always return `Some` at the time of writing this.
     fn get_body_id(&self) -> Option<BodyId>;
 }

--- a/linter_api/src/ast/item/static_item.rs
+++ b/linter_api/src/ast/item/static_item.rs
@@ -1,0 +1,44 @@
+use crate::ast::{
+    ty::{Mutability, Ty},
+    BodyId,
+};
+
+use super::{ItemBase, ItemBaseData, ItemType};
+
+/// ```ignore
+/// static mut LEVELS: u32 = 0;
+/// // `get_name()` -> `LEVELS`
+/// // `get_mutability()` -> _Mutable_
+/// // `get_ty()` -> _Ty of u32_
+/// // `get_body_id()` -> _BodyId of `0`_
+/// ```
+pub type StaticItem<'ast> = ItemBase<'ast, StaticItemData>;
+
+#[derive(Debug)]
+pub struct StaticItemData {
+    mutability: Mutability,
+    body_id: BodyId,
+}
+
+impl<'ast> ItemBaseData<'ast> for StaticItemData {
+    fn as_item_type(base: &'ast ItemBase<'ast, Self>) -> super::ItemType<'ast> {
+        ItemType::Static(base)
+    }
+}
+
+impl<'ast> StaticItem<'ast> {
+    /// The mutability of this item
+    pub fn get_mutability(&self) -> Mutability {
+        self.data.mutability
+    }
+
+    /// The defined type of this static item
+    pub fn get_ty(&'ast self) -> &'ast dyn Ty<'ast> {
+        todo!()
+    }
+
+    /// This returns the [`BodyId`] of the initialization body.
+    pub fn get_body_id(&self) -> BodyId {
+        self.data.body_id
+    }
+}

--- a/linter_api/src/context.rs
+++ b/linter_api/src/context.rs
@@ -13,7 +13,7 @@ impl<'ast> AstContext<'ast> {
     }
 }
 
-/// This trait provides the actual implementation of [`Context`]. [`Context`] is just
+/// This trait provides the actual implementation of [`AstContext`]. [`AstContext`] is just
 /// a wrapper type to avoid writing `dyn` for every context and to prevent users from
 /// implementing this trait.
 pub trait DriverContext<'ast> {}


### PR DESCRIPTION
Very descriptive title, I know.

This tries to represent static items with a wrapper type. This should work, however, the documentation page for the `StaticItem` is now split between the wrapper type functions and the specific items. See:

![image](https://user-images.githubusercontent.com/17087237/167255963-43369783-e68a-4335-b45c-f98dd7154acc.png)

![image](https://user-images.githubusercontent.com/17087237/167255986-99f854e2-9d51-4bed-a163-b1b2e550caaf.png)

The `ItemBase` documentation is additionally clustered due to the specific type dependent implementation, see:

![image](https://user-images.githubusercontent.com/17087237/167256015-68936fb0-3980-4995-a1f1-f48cd6a85374.png)

In general, I like the idea, but the documentation looks worse as a result and is less user-friendly IMO. I'll merge this as a documentation and to test a bit more with it. However, I'll focus my work on a different struct representation.

---

The CI fix just denies warnings and also tests documentation lints in CI
