### PR TITLE
Represent the static item as a struct and represent common data with helper macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,9 @@ dependencies = [
 [[package]]
 name = "linter_api"
 version = "0.1.0"
+dependencies = [
+ "visibility",
+]
 
 [[package]]
 name = "linter_driver_rustc"
@@ -144,10 +147,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "termcolor"
@@ -163,6 +195,23 @@ name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "visibility"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8881d5cc0ae34e3db2f1de5af81e5117a420d2f937506c2dc20d6f4cfb069051"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "winapi"

--- a/linter_adapter/src/lib.rs
+++ b/linter_adapter/src/lib.rs
@@ -33,6 +33,7 @@ impl<'ast> Adapter<'ast> {
                 ItemType::Mod(data) => self.external_lint_crates.check_mod(cx, *data),
                 ItemType::ExternCrate(data) => self.external_lint_crates.check_extern_crate(cx, *data),
                 ItemType::UseDecl(data) => self.external_lint_crates.check_use_decl(cx, *data),
+                ItemType::Static(data) => self.external_lint_crates.check_static_item(cx, data),
                 _ => {},
             }
         }

--- a/linter_adapter/src/loader.rs
+++ b/linter_adapter/src/loader.rs
@@ -1,6 +1,6 @@
 use libloading::Library;
 
-use linter_api::ast::item::{ExternCrateItem, ModItem, UseDeclItem};
+use linter_api::ast::item::{ExternCrateItem, ModItem, StaticItem, UseDeclItem};
 use linter_api::context::AstContext;
 use linter_api::interface::{LintPassDeclaration, LintPassRegistry};
 use linter_api::LintPass;
@@ -90,6 +90,12 @@ impl<'ast> LintPass<'ast> for ExternalLintCrateRegistry<'ast> {
     fn check_use_decl(&mut self, cx: &'ast AstContext<'ast>, use_item: &'ast dyn UseDeclItem<'ast>) {
         for lint_pass in self.lint_passes.iter_mut() {
             lint_pass.check_use_decl(cx, use_item);
+        }
+    }
+
+    fn check_static_item(&mut self, cx: &'ast AstContext<'ast>, item: &'ast StaticItem<'ast>) {
+        for lint_pass in self.lint_passes.iter_mut() {
+            lint_pass.check_static_item(cx, item);
         }
     }
 }

--- a/linter_api/Cargo.toml
+++ b/linter_api/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+visibility = "0.0.1"
 
 [features]
 # Some items should only be used by the driver implementing the functionality,

--- a/linter_api/src/ast/common.rs
+++ b/linter_api/src/ast/common.rs
@@ -23,19 +23,19 @@ impl CrateId {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BodyId {
-    krate: CrateId,
-    index: u32,
+    owner: usize,
+    index: usize,
 }
 
 #[cfg(feature = "driver-api")]
 impl BodyId {
     #[must_use]
-    pub fn new(krate: CrateId, index: u32) -> Self {
-        Self { krate, index }
+    pub fn new(owner: usize, index: usize) -> Self {
+        Self { owner, index }
     }
 
-    pub fn get_data(self) -> (CrateId, u32) {
-        (self.krate, self.index)
+    pub fn get_data(self) -> (usize, usize) {
+        (self.owner, self.index)
     }
 }
 

--- a/linter_api/src/ast/item.rs
+++ b/linter_api/src/ast/item.rs
@@ -474,7 +474,6 @@ pub enum Visibility<'ast> {
     /// Visible in the current module, equivialent to `pub(in self)` or no visibility
     PubSelf,
     PubCrate,
-    /// FIXME: Add a path value to this
     PubPath(&'ast Path<'ast>),
     PubSuper,
 }

--- a/linter_api/src/ast/item.rs
+++ b/linter_api/src/ast/item.rs
@@ -126,7 +126,7 @@ macro_rules! impl_item_data {
             }
 
             fn as_item(&'ast self) -> crate::ast::item::ItemType<'ast> {
-                crate::ast::item::ItemType::$enum_name(self)
+                $crate::ast::item::ItemType::$enum_name(self)
             }
 
             fn get_attrs(&self) {

--- a/linter_api/src/ast/item.rs
+++ b/linter_api/src/ast/item.rs
@@ -46,9 +46,7 @@ pub trait ItemData<'ast>: Debug {
     /// This returns this [`ItemData`] instance as a [`ItemType`]. This can be usefull for
     /// functions that take [`ItemType`] as a parameter. For general function calls it's better
     /// to call them directoly on the item, instead of converting it to a [`ItemType`] first.
-    fn as_item(&'ast self) -> ItemType<'ast> {
-        todo!()
-    }
+    fn as_item(&'ast self) -> ItemType<'ast>;
 
     fn get_attrs(&self); // FIXME: Add return type: -> &'ast [&'ast dyn Attribute<'ast>];
 }
@@ -100,41 +98,50 @@ macro_rules! impl_item_type_fn {
 use impl_item_type_fn;
 
 #[derive(Debug)]
-pub struct ItemBase<'ast, T: ItemBaseData<'ast>> {
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+struct CommonItemData<'ast> {
     id: ItemId,
     span: &'ast dyn Span<'ast>,
     vis: Visibility<'ast>,
     name: Option<Symbol>,
-    data: T,
 }
 
-pub trait ItemBaseData<'ast>: Debug + Sized {
-    fn as_item_type(base: &'ast ItemBase<'ast, Self>) -> ItemType<'ast>;
+macro_rules! impl_item_data {
+    ($self_name:ident, $enum_name:ident) => {
+        impl<'ast> super::ItemData<'ast> for $self_name<'ast> {
+            fn get_id(&self) -> crate::ast::item::ItemId {
+                self.data.id
+            }
+
+            fn get_span(&self) -> &'ast dyn crate::ast::Span<'ast> {
+                self.data.span
+            }
+
+            fn get_vis(&self) -> &crate::ast::item::Visibility<'ast> {
+                &self.data.vis
+            }
+
+            fn get_name(&self) -> Option<crate::ast::Symbol> {
+                self.data.name
+            }
+
+            fn as_item(&'ast self) -> crate::ast::item::ItemType<'ast> {
+                crate::ast::item::ItemType::$enum_name(self)
+            }
+
+            fn get_attrs(&self) {
+                todo!()
+            }
+        }
+    };
 }
 
-impl<'ast, T: ItemBaseData<'ast>> ItemData<'ast> for ItemBase<'ast, T> {
-    fn get_id(&self) -> ItemId {
-        self.id
-    }
+use impl_item_data;
 
-    fn get_span(&self) -> &'ast dyn Span<'ast> {
-        self.span
-    }
-
-    fn get_vis(&self) -> &Visibility<'ast> {
-        &self.vis
-    }
-
-    fn get_name(&self) -> Option<Symbol> {
-        self.name
-    }
-
-    fn get_attrs(&self) {
-        todo!()
-    }
-
-    fn as_item(&'ast self) -> ItemType<'ast> {
-        T::as_item_type(self)
+#[cfg(feature = "driver-api")]
+impl<'ast> CommonItemData<'ast> {
+    pub fn new(id: ItemId, span: &'ast dyn Span<'ast>, vis: Visibility<'ast>, name: Option<Symbol>) -> Self {
+        Self { id, span, vis, name }
     }
 }
 

--- a/linter_api/src/ast/item/static_item.rs
+++ b/linter_api/src/ast/item/static_item.rs
@@ -3,7 +3,7 @@ use crate::ast::{
     BodyId,
 };
 
-use super::{ItemBase, ItemBaseData, ItemType};
+use super::CommonItemData;
 
 /// ```ignore
 /// static mut LEVELS: u32 = 0;
@@ -12,24 +12,19 @@ use super::{ItemBase, ItemBaseData, ItemType};
 /// // `get_ty()` -> _Ty of u32_
 /// // `get_body_id()` -> _BodyId of `0`_
 /// ```
-pub type StaticItem<'ast> = ItemBase<'ast, StaticItemData>;
-
 #[derive(Debug)]
-pub struct StaticItemData {
+pub struct StaticItem<'ast> {
+    data: CommonItemData<'ast>,
     mutability: Mutability,
     body_id: BodyId,
 }
 
-impl<'ast> ItemBaseData<'ast> for StaticItemData {
-    fn as_item_type(base: &'ast ItemBase<'ast, Self>) -> super::ItemType<'ast> {
-        ItemType::Static(base)
-    }
-}
+super::impl_item_data!(StaticItem, Static);
 
 impl<'ast> StaticItem<'ast> {
     /// The mutability of this item
     pub fn get_mutability(&self) -> Mutability {
-        self.data.mutability
+        self.mutability
     }
 
     /// The defined type of this static item
@@ -39,6 +34,17 @@ impl<'ast> StaticItem<'ast> {
 
     /// This returns the [`BodyId`] of the initialization body.
     pub fn get_body_id(&self) -> BodyId {
-        self.data.body_id
+        self.body_id
+    }
+}
+
+#[cfg(feature = "driver-api")]
+impl<'ast> StaticItem<'ast> {
+    pub fn new(data: CommonItemData<'ast>, mutability: Mutability, body_id: BodyId) -> Self {
+        Self {
+            data,
+            mutability,
+            body_id,
+        }
     }
 }

--- a/linter_api/src/lib.rs
+++ b/linter_api/src/lib.rs
@@ -2,7 +2,7 @@
 #![warn(clippy::index_refutable_slice)]
 #![allow(clippy::module_name_repetitions)]
 
-use ast::item::{ExternCrateItem, ItemType, ModItem, UseDeclItem};
+use ast::item::{ExternCrateItem, ItemType, ModItem, StaticItem, UseDeclItem};
 use context::AstContext;
 use lint::Lint;
 
@@ -31,4 +31,6 @@ pub trait LintPass<'ast> {
     }
 
     fn check_use_decl(&mut self, _cx: &'ast AstContext<'ast>, _use_item: &'ast dyn UseDeclItem<'ast>) {}
+
+    fn check_static_item(&mut self, _cx: &'ast AstContext<'ast>, _item: &'ast StaticItem<'ast>) {}
 }

--- a/linter_driver_rustc/Cargo.toml
+++ b/linter_driver_rustc/Cargo.toml
@@ -11,3 +11,6 @@ linter_api = { path = "../linter_api", features = ["driver-api"] }
 linter_adapter = { path = "../linter_adapter" }
 
 bumpalo = "3.9.1"
+
+[package.metadata.rust-analyzer]
+rustc_private=true

--- a/linter_driver_rustc/src/ast/common.rs
+++ b/linter_driver_rustc/src/ast/common.rs
@@ -2,13 +2,20 @@
 
 use std::fmt::Debug;
 
-use linter_api::ast::{Attribute, CrateId, Lifetime, Path, PathResolution, PathSegment, Span, Symbol};
+use linter_api::ast::{Attribute, BodyId, CrateId, Lifetime, Path, PathResolution, PathSegment, Span, Symbol};
 
 use super::{rustc::RustcContext, ToApi};
 
 impl<'ast, 'tcx> ToApi<'ast, 'tcx, CrateId> for rustc_hir::def_id::CrateNum {
     fn to_api(&self, _cx: &'ast RustcContext<'ast, 'tcx>) -> CrateId {
         CrateId::new(self.as_u32())
+    }
+}
+
+impl<'ast, 'tcx> ToApi<'ast, 'tcx, BodyId> for rustc_hir::BodyId {
+    fn to_api(&self, _cx: &'ast RustcContext<'ast, 'tcx>) -> BodyId {
+        let (x1, x2) = self.hir_id.index();
+        BodyId::new(x1, x2)
     }
 }
 

--- a/linter_driver_rustc/src/ast/item.rs
+++ b/linter_driver_rustc/src/ast/item.rs
@@ -1,7 +1,7 @@
 #![expect(unused)]
 
 use linter_api::ast::{
-    item::{ExternCrateItem, GenericParam, ItemData, ItemId, ItemType, Visibility},
+    item::{CommonItemData, ExternCrateItem, GenericParam, ItemData, ItemId, ItemType, Visibility},
     CrateId, Symbol,
 };
 
@@ -107,3 +107,21 @@ pub fn from_rustc<'ast, 'tcx>(
 mod extern_crate_item;
 mod mod_item;
 mod use_decl;
+
+fn create_common_data<'ast, 'tcx>(
+    cx: &'ast RustcContext<'ast, 'tcx>,
+    rustc_item: &'tcx rustc_hir::Item<'tcx>,
+) -> CommonItemData<'ast> {
+    CommonItemData::new(
+        rustc_item.def_id.to_def_id().to_api(cx),
+        rustc_item.span.to_api(cx),
+        rustc_item.vis.to_api(),
+        (!rustc_item.ident.name.is_empty()).then(|| rustc_item.ident.name.to_api(cx)),
+    )
+}
+
+impl<'ast, 'tcx> ToApi<'ast, 'tcx, ItemId> for rustc_hir::def_id::DefId {
+    fn to_api(&self, cx: &'ast RustcContext<'ast, 'tcx>) -> ItemId {
+        ItemId::new(self.krate.to_api(cx), self.index.as_u32())
+    }
+}

--- a/linter_lints/src/lib.rs
+++ b/linter_lints/src/lib.rs
@@ -1,11 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use linter_api::{
-    ast::item::{ExternCrateItem, ItemType},
-    context::AstContext,
-    lint::Lint,
-    LintPass,
-};
+use linter_api::{ast::item::StaticItem, context::AstContext, lint::Lint, LintPass};
 
 linter_api::interface::export_lint_pass!("linter", TestLintPass::new());
 
@@ -24,11 +19,7 @@ impl<'ast> LintPass<'ast> for TestLintPass {
         vec![TEST_LINT]
     }
 
-    fn check_item(&mut self, _cx: &AstContext<'ast>, item: ItemType<'ast>) {
+    fn check_static_item(&mut self, _cx: &'ast AstContext<'ast>, item: &'ast StaticItem<'ast>) {
         dbg!(item);
-    }
-
-    fn check_extern_crate(&mut self, _cx: &'ast AstContext<'ast>, extern_crate_item: &'ast dyn ExternCrateItem<'ast>) {
-        dbg!(extern_crate_item);
     }
 }


### PR DESCRIPTION
This PR is related to #6. Basically, I want to remove trait objects from the interface, but also don't copy the same data in each node over and over again. This PR uses a macro to do the common data implementation for each node. Common data for a specific item can now be implemented as follows:

```rs
#[derive(Debug)]
pub struct SomeItem<'ast> {
    data: CommonItemData<'ast>,
    // Node specific data
}

// This provids access to data stored in 
super::impl_item_data!(StaticItem, Static);

// Now just add functions for node specific data
impl<'ast> SomeItem<'ast> {}
```

I also like how the documentation for the created structs looks. The red border marks the node-specific functions:

![image](https://user-images.githubusercontent.com/17087237/170383213-ff4bc521-54e9-4d01-aeaa-9acf80c77c8d.png)

This is a huge improvement to the version of #11 IMO

---

This implementation heavily depends on the representation used for nodes. See https://github.com/rust-linting/design/issues/13

---

This also adds a dependency to [visibility](https://crates.io/crates/visibility) which should be fine.
