### PR TITLE
Use rustc's error reporting mechinery

### DIFF
--- a/cargo-linter/src/main.rs
+++ b/cargo-linter/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
     }
 
     if lint_crates.iter().any(|path| path.contains(';')) {
-        eprintln!("The absolut paths of lint crates are not allowed to contain a `;`");
+        eprintln!("The absolute paths of lint crates are not allowed to contain a `;`");
         exit(-1);
     }
 

--- a/linter_api/src/ast/item.rs
+++ b/linter_api/src/ast/item.rs
@@ -49,7 +49,7 @@ pub trait ItemData<'ast>: Debug {
     /// This function can return `None` if the item was generated and has no real name
     fn get_name(&self) -> Option<Symbol>;
 
-    /// This returns this [`ItemData`] instance as a [`ItemType`]. This can be usefull for
+    /// This returns this [`ItemData`] instance as a [`ItemType`]. This can be useful for
     /// functions that take [`ItemType`] as a parameter. For general function calls it's better
     /// to call them directoly on the item, instead of converting it to a [`ItemType`] first.
     fn as_item(&'ast self) -> ItemType<'ast>;
@@ -459,7 +459,7 @@ pub trait GenericParam<'ast>: Debug {
     /// This returns the span of generic identifier.
     fn get_span(&self) -> &'ast dyn Span<'ast>;
 
-    /// This returns the name of the generic, this can retrun `None` for unnamed
+    /// This returns the name of the generic, this can return `None` for unnamed
     /// or implicit generics. For lifetimes this will include the leading apostrophe.
     ///
     /// Examples: `T`, `'ast`

--- a/linter_api/src/ast/ty.rs
+++ b/linter_api/src/ast/ty.rs
@@ -15,7 +15,7 @@ pub trait Ty<'ast>: Debug {
     }
 
     /// In the expression `let v: Vec<_> = vec![1, 2, 3]`, the type would be
-    /// `Vec<i32>` with `i32` being infered by the usage.
+    /// `Vec<i32>` with `i32` being inferred by the usage.
     fn is_infered(&self) -> bool;
 }
 

--- a/linter_api/src/ast/ty.rs
+++ b/linter_api/src/ast/ty.rs
@@ -58,7 +58,7 @@ pub enum TyKind<'ast> {
     /// Algebraic data types (ADT) for instance structs, enums and unions.
     ///
     /// The inner type is linked with the given [`TyId`] this allows the representation
-    /// of recursive datatypes, containing variations of themself and simple type comparison
+    /// of recursive data types, containing variations of themselves and simple type comparison
     /// using the [`TyId`]
     Adt(TyId),
 

--- a/linter_api/src/context.rs
+++ b/linter_api/src/context.rs
@@ -26,7 +26,6 @@ impl<'ast> AstContext<'ast> {
     }
 }
 
-
 /// This trait provides the actual implementation of [`AstContext`]. [`AstContext`] is just
 /// a wrapper type to avoid writing `dyn` for every context and to prevent users from
 /// implementing this trait.

--- a/linter_api/src/context.rs
+++ b/linter_api/src/context.rs
@@ -14,7 +14,9 @@ impl<'ast> AstContext<'ast> {
     pub fn new(cx: &'ast dyn DriverContext<'ast>) -> Self {
         Self { _cx: cx }
     }
+}
 
+impl<'ast> AstContext<'ast> {
     pub fn warn(&self, s: &str, lint: &Lint) {
         self._cx.warn(s, lint);
     }
@@ -23,6 +25,7 @@ impl<'ast> AstContext<'ast> {
         self._cx.warn_span(s, lint, sp);
     }
 }
+
 
 /// This trait provides the actual implementation of [`AstContext`]. [`AstContext`] is just
 /// a wrapper type to avoid writing `dyn` for every context and to prevent users from

--- a/linter_api/src/context.rs
+++ b/linter_api/src/context.rs
@@ -6,23 +6,23 @@ use crate::{
 /// This context will be passed to each [`super::LintPass`] call to enable the user
 /// to emit lints and to retieve nodes by the given ids.
 pub struct AstContext<'ast> {
-    _cx: &'ast dyn DriverContext<'ast>,
+    cx: &'ast dyn DriverContext<'ast>,
 }
 
 #[cfg(feature = "driver-api")]
 impl<'ast> AstContext<'ast> {
     pub fn new(cx: &'ast dyn DriverContext<'ast>) -> Self {
-        Self { _cx: cx }
+        Self { cx }
     }
 }
 
 impl<'ast> AstContext<'ast> {
-    pub fn warn(&self, s: &str, lint: &Lint) {
-        self._cx.warn(s, lint);
+    pub fn emit_lint(&self, s: &str, lint: &Lint) {
+        self.cx.emit_lint(s, lint);
     }
 
-    pub fn warn_span(&self, s: &str, lint: &Lint, sp: &dyn Span<'_>) {
-        self._cx.warn_span(s, lint, sp);
+    pub fn emit_lint_span(&self, s: &str, lint: &Lint, sp: &dyn Span<'_>) {
+        self.cx.emit_lint_span(s, lint, sp);
     }
 }
 
@@ -30,8 +30,8 @@ impl<'ast> AstContext<'ast> {
 /// a wrapper type to avoid writing `dyn` for every context and to prevent users from
 /// implementing this trait.
 pub trait DriverContext<'ast> {
-    fn warn(&self, s: &str, lint: &Lint);
-    fn warn_span(&self, s: &str, lint: &Lint, sp: &dyn Span<'_>);
+    fn emit_lint(&self, s: &str, lint: &Lint);
+    fn emit_lint_span(&self, s: &str, lint: &Lint, sp: &dyn Span<'_>);
 }
 
 /// This trait is used to create [`Symbol`]s and to turn them back into

--- a/linter_api/src/context.rs
+++ b/linter_api/src/context.rs
@@ -17,11 +17,11 @@ impl<'ast> AstContext<'ast> {
 }
 
 impl<'ast> AstContext<'ast> {
-    pub fn emit_lint(&self, s: &str, lint: &Lint) {
+    pub fn emit_lint(&self, s: &str, lint: &'ast Lint) {
         self.cx.emit_lint(s, lint);
     }
 
-    pub fn emit_lint_span(&self, s: &str, lint: &Lint, sp: &dyn Span<'_>) {
+    pub fn emit_lint_span(&self, s: &str, lint: &'ast Lint, sp: &dyn Span<'_>) {
         self.cx.emit_lint_span(s, lint, sp);
     }
 }
@@ -30,8 +30,8 @@ impl<'ast> AstContext<'ast> {
 /// a wrapper type to avoid writing `dyn` for every context and to prevent users from
 /// implementing this trait.
 pub trait DriverContext<'ast> {
-    fn emit_lint(&self, s: &str, lint: &Lint);
-    fn emit_lint_span(&self, s: &str, lint: &Lint, sp: &dyn Span<'_>);
+    fn emit_lint(&self, s: &str, lint: &'ast Lint);
+    fn emit_lint_span(&self, s: &str, lint: &'ast Lint, sp: &dyn Span<'_>);
 }
 
 /// This trait is used to create [`Symbol`]s and to turn them back into

--- a/linter_api/src/context.rs
+++ b/linter_api/src/context.rs
@@ -1,4 +1,7 @@
-use crate::ast::Symbol;
+use crate::{
+    ast::{Span, Symbol},
+    lint::Lint,
+};
 
 /// This context will be passed to each [`super::LintPass`] call to enable the user
 /// to emit lints and to retieve nodes by the given ids.
@@ -11,12 +14,23 @@ impl<'ast> AstContext<'ast> {
     pub fn new(cx: &'ast dyn DriverContext<'ast>) -> Self {
         Self { _cx: cx }
     }
+
+    pub fn warn(&self, s: &str, lint: &Lint) {
+        self._cx.warn(s, lint);
+    }
+
+    pub fn warn_span(&self, s: &str, lint: &Lint, sp: &dyn Span<'_>) {
+        self._cx.warn_span(s, lint, sp);
+    }
 }
 
 /// This trait provides the actual implementation of [`AstContext`]. [`AstContext`] is just
 /// a wrapper type to avoid writing `dyn` for every context and to prevent users from
 /// implementing this trait.
-pub trait DriverContext<'ast> {}
+pub trait DriverContext<'ast> {
+    fn warn(&self, s: &str, lint: &Lint);
+    fn warn_span(&self, s: &str, lint: &Lint, sp: &dyn Span<'_>);
+}
 
 /// This trait is used to create [`Symbol`]s and to turn them back into
 /// strings. It might be better to have a single struct like rustc does

--- a/linter_api/src/lint.rs
+++ b/linter_api/src/lint.rs
@@ -3,57 +3,163 @@
 // has to be possible in a static context.
 #[doc(hidden)]
 pub struct Lint {
+    /// A string identifier for the lint.
+    ///
+    /// This identifies the lint in attributes and in command-line arguments.
+    /// In those contexts it is always lowercase. This allows
+    /// `declare_lint!()` invocations to follow the convention of upper-case
+    /// statics without repeating the name.
+    ///
+    /// The name is written with underscores, e.g., "unused_imports".
+    /// On the command line, underscores become dashes.
+    ///
     /// See <https://rustc-dev-guide.rust-lang.org/diagnostics.html#lint-naming>
     /// for naming guidelines.
     pub name: &'static str,
+
     /// Default level for the lint.
     ///
     /// See <https://rustc-dev-guide.rust-lang.org/diagnostics.html#diagnostic-levels>
     /// for guidelines on choosing a default level.
     pub default_level: Level,
-    /// Warning, dealing with macros can be difficult. It's recommended to set this to `false`
+
+    /// Description of the lint or the issue it detects.
     ///
-    /// FIXME: Here I would prefer an enum to enable users to also select between no
-    /// linting, some linting in local macros and all linting in all macros.
-    pub report_in_macro: bool,
-    /// This text will be provided when the user if they call the explain function for
-    /// the linter. Idealy it should have a maximum with of 80 characters. It can span
-    /// over multiple lines.
-    pub explaination: &'static str,
-    // FIXME: Here I would also like a solution to add the driver specific lint instance to this struct.
-    // Currently we have to maintain a map to do this conversion.
+    /// e.g., "imports that are never used"
+    pub desc: &'static str,
+
+    /// Starting at the given edition, default to the given lint level. If this is
+    /// `None`, then use `default_level`.
+    pub edition_lint_opts: Option<(Edition, Level)>,
+
+    /// The level of macro reporting.
+    ///
+    /// See `MacroReport` for the possible levels.
+    pub report_in_macro: MacroReport,
+
+    pub future_incompatible: Option<FutureIncompatibleInfo>,
+
+    /// `Some` if this lint is feature gated, otherwise `None`.
+    pub feature_gate: Option<&'static str>,
+
+    pub crate_level_only: bool,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum MacroReport {
+    /// No reporting in local or external macros.
+    No,
+    /// Only report in local macros.
+    Local,
+    /// Report in local and external macros.
+    All,
+}
+
+/// Indicates the confidence in the correctness of a suggestion.
+///
+/// All suggestions are marked with an `Applicability`. Tools use the applicability of a
+/// suggestion to determine whether it should be automatically applied or if the user
+/// should be consulted before applying the suggestion.
+#[derive(Copy, Clone, Debug, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum Applicability {
+    /// The suggestion is definitely what the user intended, or maintains the exact
+    /// meaning of the code. This suggestion should be automatically applied.
+    ///
+    /// In case of multiple `MachineApplicable` suggestions (whether as part of
+    /// the same `multipart_suggestion` or not), all of them should be
+    /// automatically applied.
+    MachineApplicable,
+
+    /// The suggestion may be what the user intended, but it is uncertain. The suggestion
+    /// should result in valid Rust code if it is applied.
+    MaybeIncorrect,
+
+    /// The suggestion contains placeholders like `(...)` or `{ /* fields */ }`. The
+    /// suggestion cannot be applied automatically because it will not result in
+    /// valid Rust code. The user will need to fill in the placeholders.
+    HasPlaceholders,
+
+    /// The applicability of the suggestion is unknown.
+    Unspecified,
+}
+
+/// Setting for how to handle a lint.
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 #[non_exhaustive]
 pub enum Level {
-    /// The lint is allowed. A created diagnostic will not be emitted to the user.
-    /// This level can be overridden. It's usefull for rather strict lints.
     Allow,
-    /// The `warn` level will produce a warning if the lint was violated, however the
-    /// compiler will continue with its execution.
-    ///
-    /// This level might also be used in instances were the diagnostic is not emitted
-    /// to the user but used internally. This can for instance happen for lint
-    /// expectations (RFC 2383).
     Warn,
-    /// The `deny` level will produce an error and stop further execution after the lint
-    /// pass is complete.
     Deny,
+    Forbid,
+}
+
+/// Extra information for a future incompatibility lint.
+#[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
+pub struct FutureIncompatibleInfo {
+    /// e.g., a URL for an issue/PR/RFC or error code
+    pub reference: &'static str,
+    /// The reason for the lint used by diagnostics to provide
+    /// the right help message
+    pub reason: FutureIncompatibilityReason,
+    /// Whether to explain the reason to the user.
+    ///
+    /// Set to false for lints that already include a more detailed
+    /// explanation.
+    pub explain_reason: bool,
+}
+
+/// The reason for future incompatibility
+#[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
+pub enum FutureIncompatibilityReason {
+    /// This will be an error in a future release
+    /// for all editions
+    FutureReleaseError,
+    /// This will be an error in a future release, and
+    /// Cargo should create a report even for dependencies
+    FutureReleaseErrorReportNow,
+    /// Previously accepted code that will become an
+    /// error in the provided edition
+    EditionError(Edition),
+    /// Code that changes meaning in some way in
+    /// the provided edition
+    EditionSemanticsChange(Edition),
+}
+
+/// The edition of the compiler. (See [RFC 2052](https://github.com/rust-lang/rfcs/blob/master/text/2052-epochs.md).)
+#[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Debug, Eq)]
+#[non_exhaustive]
+pub enum Edition {
+    // Editions *must* be kept in order, oldest to newest.
+    /// The 2015 edition
+    Edition2015,
+    /// The 2018 edition
+    Edition2018,
+    /// The 2021 edition
+    Edition2021,
 }
 
 #[macro_export]
 macro_rules! declare_lint {
     ($(#[$attr:meta])* $NAME: ident, $LEVEL: ident, $EXPLAINATION: literal $(,)?) => {
-        $crate::lint::declare_lint!{$(#[$attr])* $NAME, $LEVEL, $EXPLAINATION, false }
+        $crate::lint::declare_lint!{$(#[$attr])* $NAME, $LEVEL, $EXPLAINATION, $crate::lint::MacroReport::No }
     };
-    ($(#[$attr:meta])* $NAME: ident, $LEVEL: ident, $EXPLAINATION: literal, $REPORT_IN_MACRO: literal $(,)? ) => {
+    ($(#[$attr:meta])* $NAME: ident, $LEVEL: ident,
+        $EXPLAINATION: literal, $REPORT_IN_MACRO: expr $(,)?
+    ) => {
         $(#[$attr])*
         pub static $NAME: &$crate::lint::Lint = &$crate::lint::Lint {
             name: stringify!($NAME),
             default_level: $crate::lint::Level::$LEVEL,
+            desc: $EXPLAINATION,
+            edition_lint_opts: None,
             report_in_macro: $REPORT_IN_MACRO,
-            explaination: $EXPLAINATION,
+            future_incompatible: None,
+            feature_gate: None,
+            crate_level_only: false,
         };
     };
 }

--- a/linter_api/src/lint.rs
+++ b/linter_api/src/lint.rs
@@ -28,12 +28,10 @@ pub struct Lint {
     /// e.g., "imports that are never used"
     pub desc: &'static str,
 
-
     /// The level of macro reporting.
     ///
     /// See `MacroReport` for the possible levels.
     pub report_in_macro: MacroReport,
-
     // TODO: do we want these
     // pub edition_lint_opts: Option<(Edition, Level)>,
     // pub future_incompatible: Option<FutureIncompatibleInfo>,

--- a/linter_api/src/lint.rs
+++ b/linter_api/src/lint.rs
@@ -28,21 +28,17 @@ pub struct Lint {
     /// e.g., "imports that are never used"
     pub desc: &'static str,
 
-    /// Starting at the given edition, default to the given lint level. If this is
-    /// `None`, then use `default_level`.
-    pub edition_lint_opts: Option<(Edition, Level)>,
 
     /// The level of macro reporting.
     ///
     /// See `MacroReport` for the possible levels.
     pub report_in_macro: MacroReport,
 
-    pub future_incompatible: Option<FutureIncompatibleInfo>,
-
-    /// `Some` if this lint is feature gated, otherwise `None`.
-    pub feature_gate: Option<&'static str>,
-
-    pub crate_level_only: bool,
+    // TODO: do we want these
+    // pub edition_lint_opts: Option<(Edition, Level)>,
+    // pub future_incompatible: Option<FutureIncompatibleInfo>,
+    // pub feature_gate: Option<&'static str>,
+    // pub crate_level_only: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Hash)]
@@ -155,11 +151,7 @@ macro_rules! declare_lint {
             name: stringify!($NAME),
             default_level: $crate::lint::Level::$LEVEL,
             desc: $EXPLAINATION,
-            edition_lint_opts: None,
             report_in_macro: $REPORT_IN_MACRO,
-            future_incompatible: None,
-            feature_gate: None,
-            crate_level_only: false,
         };
     };
 }

--- a/linter_api/src/lint.rs
+++ b/linter_api/src/lint.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 // This can sadly not be marked as #[non_exhaustive] as the struct construction
 // has to be possible in a static context.
 #[doc(hidden)]
@@ -39,7 +39,7 @@ pub struct Lint {
     // pub crate_level_only: bool,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum MacroReport {
     /// No reporting in local or external macros.

--- a/linter_driver_rustc/src/ast/common.rs
+++ b/linter_driver_rustc/src/ast/common.rs
@@ -21,7 +21,7 @@ impl<'ast, 'tcx> ToApi<'ast, 'tcx, BodyId> for rustc_hir::BodyId {
 
 #[derive(Debug)]
 pub struct RustcSpan<'ast, 'tcx> {
-    span: rustc_span::Span,
+    pub(crate) span: rustc_span::Span,
     cx: &'ast RustcContext<'ast, 'tcx>,
 }
 

--- a/linter_driver_rustc/src/ast/common.rs
+++ b/linter_driver_rustc/src/ast/common.rs
@@ -72,7 +72,7 @@ impl<'ast, 'tcx> linter_api::ast::Span<'ast> for RustcSpan<'ast, 'tcx> {
     }
 
     fn snippet(&self) -> Option<String> {
-        self.cx.lint_ctx.tcx.sess.source_map().span_to_snippet(self.span).ok()
+        self.cx.rustc_cx.tcx.sess.source_map().span_to_snippet(self.span).ok()
     }
 
     fn get_source_file(&self) -> Option<(String, u32, u32)> {

--- a/linter_driver_rustc/src/ast/common.rs
+++ b/linter_driver_rustc/src/ast/common.rs
@@ -72,7 +72,7 @@ impl<'ast, 'tcx> linter_api::ast::Span<'ast> for RustcSpan<'ast, 'tcx> {
     }
 
     fn snippet(&self) -> Option<String> {
-        self.cx.tcx.sess.source_map().span_to_snippet(self.span).ok()
+        self.cx.lint_ctx.tcx.sess.source_map().span_to_snippet(self.span).ok()
     }
 
     fn get_source_file(&self) -> Option<(String, u32, u32)> {

--- a/linter_driver_rustc/src/ast/item.rs
+++ b/linter_driver_rustc/src/ast/item.rs
@@ -32,7 +32,7 @@ pub fn from_rustc<'ast, 'tcx>(
             let items: Vec<ItemType<'_>> = rustc_mod
                 .item_ids
                 .iter()
-                .filter_map(|rustc_item| from_rustc(cx, cx.tcx.hir().item(*rustc_item)))
+                .filter_map(|rustc_item| from_rustc(cx, cx.rustc_cx.tcx.hir().item(*rustc_item)))
                 .collect();
             let items = cx.alloc_slice_from_iter(items.into_iter());
             ModItem::new(create_common_data(cx, item), items)

--- a/linter_driver_rustc/src/ast/rustc.rs
+++ b/linter_driver_rustc/src/ast/rustc.rs
@@ -49,14 +49,14 @@ fn to_leaked_rustc_lint(lint: &Lint) -> &'static RustcLint {
 }
 
 impl<'ast, 'tcx> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
-    fn warn(&self, s: &str, lint: &Lint) {
+    fn emit_lint(&self, s: &str, lint: &Lint) {
         self.lint_ctx.lint(to_leaked_rustc_lint(lint), |diag| {
             let mut diag = diag.build(s);
             diag.emit();
         });
     }
 
-    fn warn_span(&self, s: &str, lint: &Lint, sp: &dyn Span<'_>) {
+    fn emit_lint_span(&self, s: &str, lint: &Lint, sp: &dyn Span<'_>) {
         // Safety:
         //
         // Clearly this is probably not ideal but I did find this (answered by people much more

--- a/linter_driver_rustc/src/ast/rustc.rs
+++ b/linter_driver_rustc/src/ast/rustc.rs
@@ -1,5 +1,4 @@
-use rustc_lint::{LateContext, Level as RustcLevel, Lint as RustcLint, LintContext, LintStore};
-use rustc_middle::ty::TyCtxt;
+use rustc_lint::{LateContext, Level as RustcLevel, Lint as RustcLint, LintContext};
 
 use linter_api::{
     ast::{
@@ -12,11 +11,8 @@ use linter_api::{
 
 use super::{ty::RustcTy, RustcLifetime, RustcSpan};
 
-#[expect(unused)]
 pub struct RustcContext<'ast, 'tcx> {
     pub(crate) lint_ctx: &'ast LateContext<'tcx>,
-    pub(crate) tcx: TyCtxt<'tcx>,
-    pub(crate) lint_store: &'tcx LintStore,
     /// All items should be created using the `alloc_*` functions. This ensures
     /// that we can later change the way we allocate and manage our memory
     buffer: &'ast bumpalo::Bump,
@@ -141,11 +137,6 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
 impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
     #[must_use]
     pub fn new(ctx: &'ast LateContext<'tcx>, buffer: &'ast bumpalo::Bump) -> Self {
-        Self {
-            lint_ctx: ctx,
-            tcx: ctx.tcx,
-            lint_store: ctx.lint_store,
-            buffer,
-        }
+        Self { lint_ctx: ctx, buffer }
     }
 }

--- a/linter_driver_rustc/src/ast/rustc.rs
+++ b/linter_driver_rustc/src/ast/rustc.rs
@@ -12,7 +12,7 @@ use linter_api::{
 use super::{ty::RustcTy, RustcLifetime, RustcSpan};
 
 pub struct RustcContext<'ast, 'tcx> {
-    pub(crate) lint_ctx: &'ast LateContext<'tcx>,
+    pub(crate) rustc_cx: &'ast LateContext<'tcx>,
     /// All items should be created using the `alloc_*` functions. This ensures
     /// that we can later change the way we allocate and manage our memory
     buffer: &'ast bumpalo::Bump,
@@ -50,7 +50,7 @@ fn to_leaked_rustc_lint(lint: &Lint) -> &'static RustcLint {
 
 impl<'ast, 'tcx> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
     fn emit_lint(&self, s: &str, lint: &Lint) {
-        self.lint_ctx.lint(to_leaked_rustc_lint(lint), |diag| {
+        self.rustc_cx.lint(to_leaked_rustc_lint(lint), |diag| {
             let mut diag = diag.build(s);
             diag.emit();
         });
@@ -72,7 +72,7 @@ impl<'ast, 'tcx> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
             &*(sp_ptr as *const dyn std::any::Any as *const _)
         };
 
-        self.lint_ctx
+        self.rustc_cx
             .struct_span_lint(to_leaked_rustc_lint(lint), down_span.span, |diag| {
                 let mut diag = diag.build(s);
                 diag.emit();
@@ -137,6 +137,6 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
 impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
     #[must_use]
     pub fn new(ctx: &'ast LateContext<'tcx>, buffer: &'ast bumpalo::Bump) -> Self {
-        Self { lint_ctx: ctx, buffer }
+        Self { rustc_cx: ctx, buffer }
     }
 }

--- a/linter_driver_rustc/src/ast/rustc.rs
+++ b/linter_driver_rustc/src/ast/rustc.rs
@@ -34,7 +34,7 @@ fn to_leaked_rustc_lint(lint: &Lint) -> &'static RustcLint {
             Level::Forbid => RustcLevel::Forbid,
             _ => unreachable!("added variant to lint::Level"),
         },
-        desc: lint.desc,
+        desc: lint.explaination,
         edition_lint_opts: None,
         report_in_external_macro: match lint.report_in_macro {
             MacroReport::No | MacroReport::Local => false,

--- a/linter_driver_rustc/src/ast/ty.rs
+++ b/linter_driver_rustc/src/ast/ty.rs
@@ -15,7 +15,7 @@ struct TyConvContext {
 
 /// This trait is used to convert types like the normal [`ToApi`] trait. Additionally
 /// it carries the current [`TyConvContext`] used to pass information from one type to
-/// it's children. It's only intendet to be used inside this module
+/// it's children. It's only intended to be used inside this module.
 trait ToApiTy<'ast, 'tcx, T> {
     fn to_api_ty(&self, _cx: &'ast RustcContext<'ast, 'tcx>, _tccx: &mut TyConvContext) -> T;
 }
@@ -330,6 +330,6 @@ pub fn create_from_rustc_ty<'ast, 'tcx>(
         _ => todo!(),
     };
 
-    // These types are never infered as they are created from the exect rustc type
+    // These types are never infered as they are created from the exact rustc type
     cx.new_ty(kind, false)
 }

--- a/linter_driver_rustc/src/conversion.rs
+++ b/linter_driver_rustc/src/conversion.rs
@@ -37,7 +37,7 @@ fn process_items<'tcx>(rustc_cx: &LateContext<'tcx>, allocator: &mut Bump) {
     let mut adapter = Adapter::new_from_env();
 
     // Setup context
-    let driver_cx = allocator.alloc_with(|| RustcContext::new(rustc_cx.tcx, rustc_cx.lint_store, allocator));
+    let driver_cx = allocator.alloc_with(|| RustcContext::new(rustc_cx, allocator));
     let ast_cx = driver_cx.alloc_with(|| AstContext::new(driver_cx));
 
     let map = rustc_cx.tcx.hir();

--- a/linter_lints/src/lib.rs
+++ b/linter_lints/src/lib.rs
@@ -25,6 +25,6 @@ impl<'ast> LintPass<'ast> for TestLintPass {
     }
 
     fn check_static_item(&mut self, cx: &'ast AstContext<'ast>, item: &'ast StaticItem<'ast>) {
-        cx.warn_span("hey there is a static item here", TEST_LINT, item.get_span());
+        cx.emit_lint_span("hey there is a static item here", TEST_LINT, item.get_span());
     }
 }

--- a/linter_lints/src/lib.rs
+++ b/linter_lints/src/lib.rs
@@ -1,10 +1,15 @@
 #![doc = include_str!("../README.md")]
 
-use linter_api::{ast::item::StaticItem, context::AstContext, lint::Lint, LintPass};
+use linter_api::{
+    ast::item::{ItemData, StaticItem},
+    context::AstContext,
+    lint::Lint,
+    LintPass,
+};
 
 linter_api::interface::export_lint_pass!("linter", TestLintPass::new());
 
-linter_api::lint::declare_lint!(TEST_LINT, Allow, "");
+linter_api::lint::declare_lint!(TEST_LINT, Warn, "test lint warning");
 
 struct TestLintPass {}
 
@@ -19,8 +24,7 @@ impl<'ast> LintPass<'ast> for TestLintPass {
         vec![TEST_LINT]
     }
 
-    fn check_static_item(&mut self, _cx: &'ast AstContext<'ast>, _item: &'ast StaticItem<'ast>) {
-        // A placeholder output, to have a simple implementation independent ui test output
-        println!("Found static item!");
+    fn check_static_item(&mut self, cx: &'ast AstContext<'ast>, item: &'ast StaticItem<'ast>) {
+        cx.warn_span("hey there is a static item here", TEST_LINT, item.get_span());
     }
 }

--- a/linter_lints/tests/ui/find_static.stderr
+++ b/linter_lints/tests/ui/find_static.stderr
@@ -1,0 +1,10 @@
+warning: hey there is a static item here
+ --> $DIR/find_static.rs:2:1
+  |
+2 | static TEST: u32 = 4;
+  | ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(linter::test_lint)]` on by default
+
+warning: 1 warning emitted
+

--- a/linter_lints/tests/ui/find_static.stdout
+++ b/linter_lints/tests/ui/find_static.stdout
@@ -1,1 +1,0 @@
-Found static item!


### PR DESCRIPTION
Enables using `rustc_lint::LateContext` to build warnings/errors for us from our `Lint` and `dyn Span` types.

If you want I can clean up the first few commits, so it's just, fix typos, change `Lint` as one commit, then the unsafe code, and change code in `linter_lints`?