### PR TITLE
Add `linter` as a cargo alias for `linter_lints`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+linter = "run --bin cargo-linter -- -l ./linter_lints"


### PR DESCRIPTION
I think this makes running the lints a bit simple, while we don't have ui tests (which I want to work on next :))

r? @DevinR528
