### PR TITLE
Add bors-ng and add Windows and Apple CI tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Check
+name: Rust
 
 on:
   push:
@@ -8,6 +8,9 @@ on:
     - 'LICENSE-*'
     - '**.md'
     - '**.txt'
+    # Temporary branches for bors which should be ignored
+    branches-ignore:
+    - '**.tmp'
   pull_request:
     # Don't run tests, when only text files were modified
     paths-ignore:
@@ -33,17 +36,11 @@ jobs:
       with:
           toolchain: nightly-2022-04-07
           components: cargo, clippy, rustfmt
-    - name: Rustc version info
-      run: rustc -vV
-    - name: Build
-      run: cargo build
+    - run: rustc -vV
+    - run: cargo build
   
     # Tests
-    - name: Cargo tests
-      run: cargo test
-    - name: Cargo clippy
-      run: cargo clippy
-    - name: Cargo fmt
-      run: cargo fmt --check
-    - name: Cargo doc
-      run: cargo doc
+    - run: cargo test
+    - run: cargo clippy
+    - run: cargo fmt --check
+    - run: cargo doc

--- a/.github/workflows/rust_bors.yml
+++ b/.github/workflows/rust_bors.yml
@@ -1,5 +1,5 @@
-# This file has to be kept in sync with `rust_bors.yml`
-name: Rust
+# This file has to be kept in sync with `rust.yml`
+name: Rust (bors)
 
 on:
   push:
@@ -9,19 +9,11 @@ on:
     - 'LICENSE-*'
     - '**.md'
     - '**.txt'
-    # Bors magic branches, these are covered by `rust_bors`
-    branches-ignore:
-    - '**.tmp'
+    # Bors magic branches
+    branches:
     - 'staging'
     - 'trying'
     - 'master'
-  pull_request:
-    # Don't run tests, when only text files were modified
-    paths-ignore:
-    - 'COPYRIGHT'
-    - 'LICENSE-*'
-    - '**.md'
-    - '**.txt'
 
 env:
   RUST_BACKTRACE: 1
@@ -31,7 +23,11 @@ env:
 
 jobs:
   rust:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
 
     # Setup
     steps:

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,7 @@
+status = [
+    "rust (ubuntu-latest)",
+    "rust (windows-latest)",
+    "rust (macos-latest)",
+]
+delete_merged_branches = true
+timeout_sec = 1200 # 20 min

--- a/cargo-linter/src/main.rs
+++ b/cargo-linter/src/main.rs
@@ -137,8 +137,16 @@ fn prepare_lint_crate(krate: &str, verbose: bool) -> Result<String, ()> {
         return Err(());
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    let lib_file_prefix = "lib";
+    #[cfg(target_os = "windows")]
+    let lib_file_prefix = "";
+
     // FIXME: currently this expect, that the lib name is the same as the crate dir.
-    let file_name = format!("lib{}", path.file_name().and_then(|x| x.to_str()).unwrap_or_default());
+    let file_name = format!(
+        "{lib_file_prefix}{}",
+        path.file_name().and_then(|x| x.to_str()).unwrap_or_default()
+    );
     let mut krate_path = Path::new(&*LINT_KRATES_OUT_DIR).join(file_name);
 
     #[cfg(target_os = "linux")]
@@ -158,7 +166,7 @@ fn get_driver_path() -> PathBuf {
         .with_file_name("linter_driver_rustc");
 
     #[cfg(target_os = "windows")]
-    path.with_extension("exe");
+    path.set_extension("exe");
 
     path
 }

--- a/linter_lints/tests/compile_test.rs
+++ b/linter_lints/tests/compile_test.rs
@@ -67,8 +67,13 @@ fn run_test_setup() -> TestSetup {
         .args(["-l", &lint_crate_src.display().to_string(), "--test-setup"])
         .output()
         .expect("Unable to run the test setup using `cargo-linter`");
-
     let stdout = String::from_utf8(output.stdout).unwrap();
+
+    if !output.status.success() {
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        panic!("Test setup failed:\n\n===STDOUT===\n{stdout}\n\n===STDERR===\n{stderr}\n");
+    }
+
     let mut env_vars: HashMap<_, _> = stdout
         .lines()
         .filter_map(|line| line.strip_prefix("env:"))


### PR DESCRIPTION
This PR renames the existing workflow and adds a new one named `Rust checks (bors)`. The normal `Rust checks` run only uses linux as it's the fastest. I also assume that GH has more linux runners available. The bors run, used for r+ and try calls also run the other platforms.

* Example `Rust checks` run (2:26min): https://github.com/xFrednet/rust-linting/actions/runs/2537277228 
* Example `Rust checks (bors)` run (3:33 min): https://github.com/xFrednet/rust-linting/actions/runs/2537290584

That's it. For now, I'll add myself and @DevinR528 as a reviewer. I'm also fine with r+ own PRs, the usage of bors should mainly ensure that our master is always stable and that we save CI time. A full all OS run takes longer than a single linux run. And that's it, let's see if everything works.

Closes: #22