### PR TITLE
Remove master rerun since bors check carries over on the commit

### DIFF
--- a/.github/workflows/rust_bors.yml
+++ b/.github/workflows/rust_bors.yml
@@ -13,7 +13,6 @@ on:
     branches:
     - 'staging'
     - 'trying'
-    - 'master'
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
This stops the rerun of the CI steps, since they've been checked by bors on the merge :upside_down_face: 