### PR TITLE
Use `#![warn(clippy::pedantic)]`

### DIFF
--- a/cargo-linter/src/main.rs
+++ b/cargo-linter/src/main.rs
@@ -1,7 +1,9 @@
 #![feature(once_cell)]
+#![warn(clippy::pedantic)]
 #![warn(clippy::index_refutable_slice)]
 
 use std::{
+    ffi::OsStr,
     fs::create_dir_all,
     path::{Path, PathBuf},
     process::{exit, Command},
@@ -76,7 +78,7 @@ fn main() {
         println!("env:RUSTC_WORKSPACE_WRAPPER={}", driver_path.display());
         println!("env:LINTER_LINT_CRATES={linter_crates_env}");
     } else {
-        run_driver(&driver_path, &linter_crates_env)
+        run_driver(&driver_path, &linter_crates_env);
     }
 }
 
@@ -145,7 +147,7 @@ fn prepare_lint_crate(krate: &str, verbose: bool) -> Result<String, ()> {
     // FIXME: currently this expect, that the lib name is the same as the crate dir.
     let file_name = format!(
         "{lib_file_prefix}{}",
-        path.file_name().and_then(|x| x.to_str()).unwrap_or_default()
+        path.file_name().and_then(OsStr::to_str).unwrap_or_default()
     );
     let mut krate_path = Path::new(&*LINT_KRATES_OUT_DIR).join(file_name);
 

--- a/linter_adapter/src/lib.rs
+++ b/linter_adapter/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![warn(clippy::pedantic)]
 #![warn(clippy::index_refutable_slice)]
 
 mod loader;

--- a/linter_adapter/src/loader.rs
+++ b/linter_adapter/src/loader.rs
@@ -8,7 +8,7 @@ use linter_api::LintPass;
 #[derive(Default)]
 pub struct ExternalLintCrateRegistry<'ast> {
     pub lint_passes: Vec<Box<dyn LintPass<'ast>>>,
-    _libs: Vec<Library>,
+    libs: Vec<Library>,
 }
 
 impl<'a> ExternalLintCrateRegistry<'a> {
@@ -33,7 +33,7 @@ impl<'a> ExternalLintCrateRegistry<'a> {
             (decl.register)(self);
         }
 
-        self._libs.push(lib);
+        self.libs.push(lib);
 
         Ok(())
     }
@@ -72,29 +72,29 @@ impl<'ast> LintPass<'ast> for ExternalLintCrateRegistry<'ast> {
     }
 
     fn check_item(&mut self, cx: &'ast AstContext<'ast>, item: linter_api::ast::item::ItemType<'ast>) {
-        for lint_pass in self.lint_passes.iter_mut() {
+        for lint_pass in &mut self.lint_passes {
             lint_pass.check_item(cx, item);
         }
     }
 
     fn check_mod(&mut self, cx: &'ast AstContext<'ast>, mod_item: &'ast ModItem<'ast>) {
-        for lint_pass in self.lint_passes.iter_mut() {
+        for lint_pass in &mut self.lint_passes {
             lint_pass.check_mod(cx, mod_item);
         }
     }
     fn check_extern_crate(&mut self, cx: &'ast AstContext<'ast>, extern_crate_item: &'ast ExternCrateItem<'ast>) {
-        for lint_pass in self.lint_passes.iter_mut() {
+        for lint_pass in &mut self.lint_passes {
             lint_pass.check_extern_crate(cx, extern_crate_item);
         }
     }
     fn check_use_decl(&mut self, cx: &'ast AstContext<'ast>, use_item: &'ast UseDeclItem<'ast>) {
-        for lint_pass in self.lint_passes.iter_mut() {
+        for lint_pass in &mut self.lint_passes {
             lint_pass.check_use_decl(cx, use_item);
         }
     }
 
     fn check_static_item(&mut self, cx: &'ast AstContext<'ast>, item: &'ast StaticItem<'ast>) {
-        for lint_pass in self.lint_passes.iter_mut() {
+        for lint_pass in &mut self.lint_passes {
             lint_pass.check_static_item(cx, item);
         }
     }

--- a/linter_api/src/ast/item/static_item.rs
+++ b/linter_api/src/ast/item/static_item.rs
@@ -29,6 +29,7 @@ impl<'ast> StaticItem<'ast> {
 
     /// The defined type of this static item
     pub fn get_ty(&'ast self) -> &'ast dyn Ty<'ast> {
+        #![allow(clippy::missing_panics_doc, clippy::unused_self)]
         todo!()
     }
 

--- a/linter_api/src/lib.rs
+++ b/linter_api/src/lib.rs
@@ -1,6 +1,9 @@
 #![doc = include_str!("../README.md")]
+#![warn(clippy::pedantic)]
 #![warn(clippy::index_refutable_slice)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::trivially_copy_pass_by_ref)]
 
 use ast::item::{ExternCrateItem, ItemType, ModItem, StaticItem, UseDeclItem};
 use context::AstContext;

--- a/linter_driver_rustc/src/ast/item.rs
+++ b/linter_driver_rustc/src/ast/item.rs
@@ -54,19 +54,19 @@ pub fn from_rustc<'ast, 'tcx>(
                 rustc_body_id.to_api(cx),
             )
         })),
-        rustc_hir::ItemKind::Const(..) => None?,
-        rustc_hir::ItemKind::Fn(..) => None?,
-        rustc_hir::ItemKind::Macro(..) => None?,
-        rustc_hir::ItemKind::ForeignMod { .. } => None?,
-        rustc_hir::ItemKind::GlobalAsm(..) => None?,
-        rustc_hir::ItemKind::TyAlias(..) => None?,
-        rustc_hir::ItemKind::OpaqueTy(..) => None?,
-        rustc_hir::ItemKind::Enum(..) => None?,
-        rustc_hir::ItemKind::Struct(..) => None?,
-        rustc_hir::ItemKind::Union(..) => None?,
-        rustc_hir::ItemKind::Trait(..) => None?,
-        rustc_hir::ItemKind::TraitAlias(..) => None?,
-        rustc_hir::ItemKind::Impl(..) => None?,
+        rustc_hir::ItemKind::Const(..)
+        | rustc_hir::ItemKind::Fn(..)
+        | rustc_hir::ItemKind::Macro(..)
+        | rustc_hir::ItemKind::ForeignMod { .. }
+        | rustc_hir::ItemKind::GlobalAsm(..)
+        | rustc_hir::ItemKind::TyAlias(..)
+        | rustc_hir::ItemKind::OpaqueTy(..)
+        | rustc_hir::ItemKind::Enum(..)
+        | rustc_hir::ItemKind::Struct(..)
+        | rustc_hir::ItemKind::Union(..)
+        | rustc_hir::ItemKind::Trait(..)
+        | rustc_hir::ItemKind::TraitAlias(..)
+        | rustc_hir::ItemKind::Impl(..) => return None,
     })
 }
 
@@ -93,8 +93,8 @@ fn vis_from_rustc<'ast, 'tcx>(
         {
             Visibility::PubCrate
         },
-        rustc_middle::ty::Visibility::Invisible => Visibility::None,
-        _ => Visibility::None, // FIXME: Fix visibility conversion. See #26
+        // FIXME: Fix visibility conversion. See #26
+        rustc_middle::ty::Visibility::Restricted(_) | rustc_middle::ty::Visibility::Invisible => Visibility::None,
     }
 }
 

--- a/linter_driver_rustc/src/ast/ty.rs
+++ b/linter_driver_rustc/src/ast/ty.rs
@@ -252,6 +252,7 @@ fn ty_id_from_def_id(did: rustc_span::def_id::DefId) -> TyId {
     TyId::new(CrateId::new(did.krate.as_u32()), did.index.as_u32())
 }
 
+#[allow(clippy::missing_panics_doc)] // TODO
 pub fn create_from_rustc_ty<'ast, 'tcx>(
     cx: &'ast RustcContext<'ast, 'tcx>,
     rustc_ty: rustc_middle::ty::Ty<'tcx>,

--- a/linter_driver_rustc/src/conversion.rs
+++ b/linter_driver_rustc/src/conversion.rs
@@ -24,7 +24,7 @@ impl_lint_pass!(ConverterLintPass => []);
 impl<'tcx> LateLintPass<'tcx> for ConverterLintPass {
     fn check_crate(&mut self, rustc_cx: &LateContext<'tcx>) {
         let mut bump = Bump::new();
-        process_items(rustc_cx, &mut bump)
+        process_items(rustc_cx, &mut bump);
     }
 }
 

--- a/linter_driver_rustc/src/main.rs
+++ b/linter_driver_rustc/src/main.rs
@@ -2,7 +2,9 @@
 #![feature(rustc_private)]
 #![feature(lint_reasons)]
 #![warn(rustc::internal)]
+#![warn(clippy::pedantic)]
 #![warn(clippy::index_refutable_slice)]
+#![allow(clippy::module_name_repetitions)]
 
 extern crate rustc_ast;
 extern crate rustc_data_structures;
@@ -183,10 +185,10 @@ fn main() {
         // FIXME: Add this:
         //  let in_primary_package = env::var("CARGO_PRIMARY_PACKAGE").is_ok();
 
-        if !cap_lints_allow {
-            rustc_driver::RunCompiler::new(&orig_args, &mut LinterCallback).run()
-        } else {
+        if cap_lints_allow {
             rustc_driver::RunCompiler::new(&orig_args, &mut DefaultCallbacks).run()
+        } else {
+            rustc_driver::RunCompiler::new(&orig_args, &mut LinterCallback).run()
         }
     }))
 }

--- a/linter_lints/src/lib.rs
+++ b/linter_lints/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![warn(clippy::pedantic)]
 
 use linter_api::{
     ast::item::{ItemData, StaticItem},


### PR DESCRIPTION
Fixes #29.