### PR TITLE
Rework lint-crate -> driver communication 

### DIFF
--- a/linter_adapter/README.md
+++ b/linter_adapter/README.md
@@ -1,16 +1,21 @@
-# _The Adapter_
+# Linter Adapter 🔌
 
-The adapter connects the lint driver with lint crates. :electric_plug:
+The adapter provides a common interface for linter drivers to communicate with lint crates. It does some heavy lifting which would otherwise need to be done by each individual driver.
 
-:warning: This crate is not part of the stable API :warning: 
+⚠️ This is not part of the stable API, the adapter might change in between releases ⚠️
 
 ## Interface
 
-The adapter usually gets created from the environment. The following environment values can be used:
-* `LINTER_LINT_CRATES`: A semicolon separated list of dynamic libraries belonging to lint crates. Ideally, these should hold absolute paths.
+### Driver -> lint crate communication
 
-  Example: `/path/to/lint_crates/one.so;/path/to/lint_crates/two.so`
+The adapter can load defined lint crates and send information from the driver to all lint crates. The driver takes care of save ABI communication from the driver to the lint crates.
 
-## Implementation
+### Lint crate -> driver communication
 
-This crate currently loads lint crates as dynamic libraries. The general concept is based on [this article](https://adventures.michaelfbryan.com/posts/plugins-in-rust/). The implementation transfers a trait object over the C ABI, which is kind of undefined. See [`improper_ctypes_definitions`](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#improper-ctypes-definitions) for a brief explanation. This currently works but might break in the future, this should be changed before `v1.0.0`.
+The linting API and lint crates require some callbacks into the driver. These callbacks use `extern "C"` functions with FFI safe types. Drivers can just implement the `DriverContext` trait provided by the adapter, all FFI related conversion is done by the adapter.
+
+### Creating an adapter instance
+
+An adapter instance for the specific driver can be crated from the environment. For this, the following environment values are read:
+
+* `LINTER_LINT_CRATES`: A semicolon separated list of lint crates in the form of compiled dynamic libraries.

--- a/linter_adapter/src/context.rs
+++ b/linter_adapter/src/context.rs
@@ -1,0 +1,45 @@
+use linter_api::{ast::Span, context::DriverCallbacks, lint::Lint};
+
+/// ### Safety
+///
+/// `&dyn` objects are theoretically not FFI safe since their type layout can
+/// change and calling functions on them would require a stable ABI which Rust
+/// doesn't provide.
+///
+/// In this case, the `DriverContextWrapper` will be passes as a `*const ()`
+/// pointer to [`DriverCallbacks`] which will do nothing with this data other
+/// than giving it back to functions declared in this module. Since the `&dyn`
+/// object is created, only used here and everything is compiled during the same
+/// compiler run, it should be safe to use `&dyn`.
+#[repr(C)]
+pub struct DriverContextWrapper<'ast> {
+    driver_cx: &'ast dyn DriverContext<'ast>,
+}
+
+impl<'ast> DriverContextWrapper<'ast> {
+    #[must_use]
+    pub fn new(driver_cx: &'ast dyn DriverContext<'ast>) -> Self {
+        Self { driver_cx }
+    }
+
+    #[must_use]
+    pub fn create_driver_callback(&'ast self) -> DriverCallbacks<'ast> {
+        let wrapper_ptr: *const Self = self;
+        DriverCallbacks {
+            driver_context: wrapper_ptr.cast::<()>(),
+            emit_lint,
+        }
+    }
+}
+
+#[expect(improper_ctypes_definitions)]
+extern "C" fn emit_lint<'ast>(data: *const (), lint: &'static Lint, msg: &str, span: &dyn Span<'ast>) {
+    let data = data.cast::<DriverContextWrapper<'ast>>();
+    let wrapper: &'ast DriverContextWrapper<'ast> = unsafe { data.as_ref() }.unwrap();
+
+    wrapper.driver_cx.emit_lint(lint, msg, span);
+}
+
+pub trait DriverContext<'ast> {
+    fn emit_lint(&self, lint: &'static Lint, msg: &str, span: &dyn Span<'ast>);
+}

--- a/linter_adapter/src/context.rs
+++ b/linter_adapter/src/context.rs
@@ -28,9 +28,8 @@ impl<'ast> DriverContextWrapper<'ast> {
 
     #[must_use]
     pub fn create_driver_callback(&'ast self) -> DriverCallbacks<'ast> {
-        let wrapper_ptr: *const Self = self;
         DriverCallbacks {
-            driver_context: wrapper_ptr.cast::<()>(),
+            driver_context:  unsafe { &*(self as *const DriverContextWrapper).cast::<()>() },
             emit_lint,
             get_span,
             span_snippet,
@@ -39,25 +38,19 @@ impl<'ast> DriverContextWrapper<'ast> {
 }
 
 #[expect(improper_ctypes_definitions)]
-extern "C" fn emit_lint<'ast>(data: *const (), lint: &'static Lint, msg: &str, span: &Span<'ast>) {
-    let data = data.cast::<DriverContextWrapper<'ast>>();
-    let wrapper: &'ast DriverContextWrapper<'ast> = unsafe { data.as_ref() }.unwrap();
-
+extern "C" fn emit_lint<'ast>(data: &(), lint: &'static Lint, msg: &str, span: &Span<'ast>) {
+    let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
     wrapper.driver_cx.emit_lint(lint, msg, span);
 }
 
-extern "C" fn get_span<'ast>(data: *const (), owner: &SpanOwner) -> &'ast Span<'ast> {
-    let data = data.cast::<DriverContextWrapper<'ast>>();
-    let wrapper: &'ast DriverContextWrapper<'ast> = unsafe { data.as_ref() }.unwrap();
-
+extern "C" fn get_span<'ast>(data: &(), owner: &SpanOwner) -> &'ast Span<'ast> {
+    let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
     wrapper.driver_cx.get_span(owner)
 }
 
 #[expect(improper_ctypes_definitions)]
-extern "C" fn span_snippet<'ast>(data: *const (), span: &Span) -> Option<&'ast str> {
-    let data = data.cast::<DriverContextWrapper<'ast>>();
-    let wrapper: &'ast DriverContextWrapper<'ast> = unsafe { data.as_ref() }.unwrap();
-
+extern "C" fn span_snippet<'ast>(data: &(), span: &Span) -> Option<&'ast str> {
+    let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
     wrapper.driver_cx.span_snippet(span)
 }
 

--- a/linter_adapter/src/lib.rs
+++ b/linter_adapter/src/lib.rs
@@ -2,8 +2,11 @@
 #![feature(lint_reasons)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::index_refutable_slice)]
+#![allow(clippy::module_name_repetitions)]
 
+pub mod context;
 mod loader;
+
 use linter_api::{
     ast::{item::ItemType, Crate},
     context::AstContext,

--- a/linter_api/README.md
+++ b/linter_api/README.md
@@ -46,6 +46,6 @@ impl<'ast> LintPass<'ast> for TestLintPass {
 // Last but not least, we have to mark our object that implements `LintPass`.
 // Each lint crate requires exactly one marker. All lints have to be implemented
 // in one lint pass. For multiple lints it can be helpful to extract the individual
-// linting logic called by the `check_*` functions into separate module.
+// linting logic called by the `check_*` functions into separate modules.
 linter_api::interface::export_lint_pass!(TestLintPass);
 ```

--- a/linter_api/src/ast/common.rs
+++ b/linter_api/src/ast/common.rs
@@ -1,43 +1,10 @@
+mod id;
+pub use id::*;
+//mod span;
+
 use std::fmt::Debug;
 
 use super::item::ItemId;
-
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CrateId {
-    index: u32,
-}
-
-#[cfg(feature = "driver-api")]
-impl CrateId {
-    #[must_use]
-    pub fn new(index: u32) -> Self {
-        Self { index }
-    }
-
-    pub fn get_data(self) -> u32 {
-        self.index
-    }
-}
-
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BodyId {
-    owner: usize,
-    index: usize,
-}
-
-#[cfg(feature = "driver-api")]
-impl BodyId {
-    #[must_use]
-    pub fn new(owner: usize, index: usize) -> Self {
-        Self { owner, index }
-    }
-
-    pub fn get_data(self) -> (usize, usize) {
-        (self.owner, self.index)
-    }
-}
 
 /// A `Span` represents a span of source code. It can be part of the source code
 /// or part of generated logic using macros. Spans are used to determine the origin

--- a/linter_api/src/ast/common.rs
+++ b/linter_api/src/ast/common.rs
@@ -7,106 +7,6 @@ use std::fmt::Debug;
 
 use super::item::ItemId;
 
-/// A `Span` represents a span of source code. It can be part of the source code
-/// or part of generated logic using macros. Spans are used to determine the origin
-/// of elements and to create suggestions and lint messages.
-///
-/// Note: When working with [`Span`]s and modifying their bounds it can happen that
-/// they end inside a unicode character as they often safe the unicode position. These
-/// cases can cause panics if they are used to access the underlying source code. The
-/// normal provided [`Span`]s should all be fine.
-pub trait SpanOld<'ast>: Debug {
-    fn is_from_expansion(&self) -> bool;
-
-    fn in_derive_expansion(&self) -> bool;
-
-    // Returns `true` if `self` fully encloses `other`
-    fn contains(&self, other: &dyn SpanOld<'ast>) -> bool;
-
-    // Returns `true` if `self` touches `other`
-    fn overlaps(&self, other: &dyn SpanOld<'ast>) -> bool;
-
-    // Edition of the crate from which this span came.
-    fn edition(&self) -> Edition;
-
-    /// Returns a `Span` that would enclose both `self` and `end`.
-    ///
-    /// ```text
-    ///     ____             ___
-    ///     self lorem ipsum end
-    ///     ^^^^^^^^^^^^^^^^^^^^
-    /// ```
-    fn to(&'ast self, end: &dyn SpanOld<'ast>) -> &dyn SpanOld<'ast>;
-
-    /// Returns a `Span` between the end of `self` to the beginning of `end`.
-    ///
-    /// ```text
-    ///     ____             ___
-    ///     self lorem ipsum end
-    ///         ^^^^^^^^^^^^^
-    /// ```
-    fn between(&'ast self, end: &dyn SpanOld<'ast>) -> &dyn SpanOld<'ast>;
-
-    /// Returns a `Span` from the beginning of `self` until the beginning of `end`.
-    ///
-    /// ```text
-    ///     ____             ___
-    ///     self lorem ipsum end
-    ///     ^^^^^^^^^^^^^^^^^
-    /// ```
-    fn until(&'ast self, end: &dyn SpanOld<'ast>) -> &dyn SpanOld<'ast>;
-
-    /// Returns the code that this span references or `None` if the code in unavailable
-    fn snippet(&self) -> Option<String>;
-
-    /// Converts a span to a code snippet if available, otherwise returns the default.
-    ///
-    /// This is useful if you want to provide suggestions for your lint or more generally, if you
-    /// want to convert a given `Span` to a `String`. To create suggestions consider using
-    /// [`Span::snippet_with_applicability`] to ensure that the [`Applicability`] stays correct.
-    ///
-    /// # Example
-    /// ```rust,ignore
-    /// // Given two spans one for `value` and one for the `init` expression.
-    /// let value = Vec::new();
-    /// //  ^^^^^   ^^^^^^^^^^
-    /// //  span1   span2
-    ///
-    /// // The snipped call would return the corresponding code snippets
-    /// span1.snippet_or_else("..") // -> "value"
-    /// span2.snippet_or_else("..") // -> "Vec::new()"
-    /// ```
-    fn snippet_or_else(&self, default: &str) -> String {
-        self.snippet().unwrap_or_else(|| default.to_string())
-    }
-
-    /// Same as [`Span::snippet`], but it adapts the applicability level by following rules:
-    ///
-    /// - Applicability level `Unspecified` will never be changed.
-    /// - If the span is inside a macro, change the applicability level to `MaybeIncorrect`.
-    /// - If the default value is used and the applicability level is `MachineApplicable`, change it
-    ///   to
-    /// `HasPlaceholders`
-    fn snippet_with_applicability(&self, default: &str, applicability: &mut Applicability) -> String {
-        if *applicability != Applicability::Unspecified && self.is_from_expansion() {
-            *applicability = Applicability::MaybeIncorrect;
-        }
-        self.snippet().unwrap_or_else(|| {
-            if *applicability == Applicability::MachineApplicable {
-                *applicability = Applicability::HasPlaceholders;
-            }
-            default.to_string()
-        })
-    }
-
-    /// Returns information about the File that this `Span` originates from if available.
-    ///
-    /// The structure is: `(<file>, <lint>, <column>)`
-    ///
-    /// FIXME: We should probably create a `File` struct or something for this (xFrednet)
-    fn get_source_file(&self) -> Option<(String, u32, u32)>;
-}
-
 #[non_exhaustive]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Edition {
@@ -175,13 +75,13 @@ pub enum Abi {
 
 pub struct Spanned<'ast, T> {
     pub node: T,
-    pub span: &'ast dyn SpanOld<'ast>,
+    pub span: &'ast Span<'ast>,
 }
 
 #[cfg(feature = "driver-api")]
 impl<'ast, T> Spanned<'ast, T> {
     #[must_use]
-    pub fn new(node: T, span: &'ast dyn SpanOld<'ast>) -> Self {
+    pub fn new(node: T, span: &'ast Span<'ast>) -> Self {
         Self { node, span }
     }
 }

--- a/linter_api/src/ast/common.rs
+++ b/linter_api/src/ast/common.rs
@@ -1,6 +1,5 @@
 mod id;
 pub use id::*;
-//mod span;
 
 use std::fmt::Debug;
 

--- a/linter_api/src/ast/common/id.rs
+++ b/linter_api/src/ast/common/id.rs
@@ -1,9 +1,9 @@
 /// This ID uniquely identifies a crate during compilation.
 ///
 /// The ID of a specific crate can change between different compilations.
+#[repr(C)]
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(C)]
 pub struct CrateId {
     index: u32,
 }
@@ -23,9 +23,9 @@ impl CrateId {
 /// This ID uniquely identifies a body during compilation.
 ///
 /// The ID of a specific body can change between different compilations.
+#[repr(C)]
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(C)]
 pub struct BodyId {
     owner: usize,
     index: usize,
@@ -40,5 +40,33 @@ impl BodyId {
 
     pub fn get_data(self) -> (usize, usize) {
         (self.owner, self.index)
+    }
+}
+
+/// **Unstable**
+///
+/// This id is used to identify [`Span`]s. This type is only intended for internal
+/// use. Lint crates should always get a [`Span`] object.
+///
+/// The layout of the data is up to the driver implementation. The API will never
+/// create custom IDs and pass them to the driver. The size of this type might
+/// change. Drivers should validate the size with tests.
+#[repr(C)]
+#[doc(hidden)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+#[cfg_attr(not(feature = "driver-api"), visibility::make(pub(crate)))]
+struct SpanId {
+    data: u64,
+}
+
+#[cfg(feature = "driver-api")]
+impl SpanId {
+    #[must_use]
+    pub fn new(data: u64) -> Self {
+        Self { data }
+    }
+
+    pub fn get_data(self) -> u64 {
+        self.data
     }
 }

--- a/linter_api/src/ast/common/id.rs
+++ b/linter_api/src/ast/common/id.rs
@@ -54,8 +54,7 @@ impl BodyId {
 #[repr(C)]
 #[doc(hidden)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
-#[cfg_attr(not(feature = "driver-api"), visibility::make(pub(crate)))]
-struct SpanId {
+pub(crate) struct SpanId {
     data: u64,
 }
 

--- a/linter_api/src/ast/common/id.rs
+++ b/linter_api/src/ast/common/id.rs
@@ -1,0 +1,44 @@
+/// This ID uniquely identifies a crate during compilation.
+///
+/// The ID of a specific crate can change between different compilations.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+pub struct CrateId {
+    index: u32,
+}
+
+#[cfg(feature = "driver-api")]
+impl CrateId {
+    #[must_use]
+    pub fn new(index: u32) -> Self {
+        Self { index }
+    }
+
+    pub fn get_data(self) -> u32 {
+        self.index
+    }
+}
+
+/// This ID uniquely identifies a body during compilation.
+///
+/// The ID of a specific body can change between different compilations.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+pub struct BodyId {
+    owner: usize,
+    index: usize,
+}
+
+#[cfg(feature = "driver-api")]
+impl BodyId {
+    #[must_use]
+    pub fn new(owner: usize, index: usize) -> Self {
+        Self { owner, index }
+    }
+
+    pub fn get_data(self) -> (usize, usize) {
+        (self.owner, self.index)
+    }
+}

--- a/linter_api/src/ast/common/span.rs
+++ b/linter_api/src/ast/common/span.rs
@@ -1,0 +1,153 @@
+use std::path::PathBuf;
+
+use crate::{ast::item::ItemId, context::AstContext};
+
+use super::{Applicability, BodyId, ItemPath, SpanId};
+
+#[repr(C)]
+#[doc(hidden)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+enum SpanSource<'ast> {
+    File(&'ast PathBuf),
+    Macro(&'ast ItemPath<'ast>),
+}
+
+#[derive(Clone)]
+pub struct Span<'ast> {
+    cx: &'ast AstContext<'ast>,
+    source: SpanSource<'ast>,
+    /// The start marks the first byte in the [`SpanSource`] that is included in this
+    /// span. The span continues until the end position.
+    start: usize,
+    end: usize,
+}
+
+impl<'ast> Span<'ast> {
+    pub fn is_from_file(&self) -> bool {
+        matches!(self.source, SpanSource::File(..))
+    }
+
+    pub fn is_from_macro(&self) -> bool {
+        matches!(self.source, SpanSource::Macro(..))
+    }
+
+    /// Returns `true` if the span has a length of 0. This means that no bytes are
+    /// inside the span.
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+
+    /// Returns true, if both spans originate from the sane source. This can for
+    /// instance be the same source file or macro expansion.
+    pub fn is_same_source(&self, other: &Span<'ast>) -> bool {
+        self.source == other.source
+    }
+
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    pub fn set_start(&mut self, start: usize) {
+        self.start = start;
+    }
+
+    pub fn end(&self) -> usize {
+        self.end
+    }
+
+    pub fn set_end(&mut self, end: usize) {
+        self.end = end;
+    }
+
+    /// Returns the code that this span references or `None` if the code in unavailable
+    pub fn snippet(&self) -> Option<String> {
+        self.cx.span_snipped(self)
+    }
+
+    /// Converts a span to a code snippet if available, otherwise returns the default.
+    ///
+    /// This is useful if you want to provide suggestions for your lint or more generally, if you
+    /// want to convert a given `Span` to a `String`. To create suggestions consider using
+    /// [`Span::snippet_with_applicability`] to ensure that the [`Applicability`] stays correct.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// // Given two spans one for `value` and one for the `init` expression.
+    /// let value = Vec::new();
+    /// //  ^^^^^   ^^^^^^^^^^
+    /// //  span1   span2
+    ///
+    /// // The snipped call would return the corresponding code snippets
+    /// span1.snippet_or_else("..") // -> "value"
+    /// span2.snippet_or_else("..") // -> "Vec::new()"
+    /// ```
+    pub fn snippet_or_else(&self, default: &str) -> String {
+        self.snippet().unwrap_or_else(|| default.to_string())
+    }
+
+    /// Same as [`Span::snippet`], but it adapts the applicability level by following rules:
+    ///
+    /// - Applicability level `Unspecified` will never be changed.
+    /// - If the span is inside a macro, change the applicability level to `MaybeIncorrect`.
+    /// - If the default value is used and the applicability level is `MachineApplicable`, change it
+    ///   to `HasPlaceholders`
+    pub fn snippet_with_applicability(&self, default: &str, applicability: &mut Applicability) -> String {
+        if *applicability != Applicability::Unspecified && self.is_from_macro() {
+            *applicability = Applicability::MaybeIncorrect;
+        }
+        self.snippet().unwrap_or_else(|| {
+            if *applicability == Applicability::MachineApplicable {
+                *applicability = Applicability::HasPlaceholders;
+            }
+            default.to_string()
+        })
+    }
+}
+
+#[cfg(feature = "driver-api")]
+impl<'ast> Span<'ast> {
+    pub fn new(cx: &'ast AstContext<'ast>, source: SpanSource<'ast>, start: usize, end: usize) -> Self {
+        Self { cx, source, start, end }
+    }
+
+    pub fn source(&self) -> SpanSource {
+        self.source
+    }
+}
+
+/// **Unstable**
+///
+/// This enum is used to requrest a `Span` instance from the driver context.
+/// it is only an internal type to avoid mapping every `Span`, since they are
+/// most often not needed.
+#[repr(C)]
+#[doc(hidden)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+#[cfg_attr(not(feature = "driver-api"), visibility::make(pub(crate)))]
+enum SpanOwner {
+    /// This requrests the `Span` belonging to the [`ItemId`].
+    Item(ItemId),
+    /// This requrests the `Span` belonging to the [`BodyId`].
+    Body(BodyId),
+    /// This requests the `Span` belonging to a driver generated [`SpanId`]
+    SpecificSpan(SpanId),
+}
+
+impl From<ItemId> for SpanOwner {
+    fn from(id: ItemId) -> Self {
+        Self::Item(id)
+    }
+}
+
+impl From<BodyId> for SpanOwner {
+    fn from(id: BodyId) -> Self {
+        Self::Body(id)
+    }
+}
+
+impl From<SpanId> for SpanOwner {
+    fn from(id: SpanId) -> Self {
+        Self::SpecificSpan(id)
+    }
+}

--- a/linter_api/src/ast/common/span.rs
+++ b/linter_api/src/ast/common/span.rs
@@ -7,6 +7,7 @@ use super::{Applicability, BodyId, ItemPath, SpanId};
 #[repr(C)]
 #[doc(hidden)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(not(feature = "driver-api"), allow(dead_code))]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
 enum SpanSource<'ast> {
     File(&'ast PathBuf),

--- a/linter_api/src/ast/common/span.rs
+++ b/linter_api/src/ast/common/span.rs
@@ -124,8 +124,7 @@ impl<'ast> Span<'ast> {
 #[repr(C)]
 #[doc(hidden)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
-#[cfg_attr(not(feature = "driver-api"), visibility::make(pub(crate)))]
-enum SpanOwner {
+pub(crate) enum SpanOwner {
     /// This requrests the `Span` belonging to the [`ItemId`].
     Item(ItemId),
     /// This requrests the `Span` belonging to the [`BodyId`].

--- a/linter_api/src/ast/item.rs
+++ b/linter_api/src/ast/item.rs
@@ -13,7 +13,7 @@ pub use self::use_decl_item::UseDeclItem;
 
 use super::{
     ty::{Ty, TyId},
-    Abi, Asyncness, Attribute, BodyId, Constness, CrateId, ItemPath, Pattern, Safety, Span, SpanOld, Symbol,
+    Abi, Asyncness, Attribute, BodyId, Constness, CrateId, ItemPath, Pattern, Safety, Span, Symbol,
 };
 
 /// Every item has an ID that can be used to retive that item or compair it to
@@ -215,7 +215,7 @@ pub trait FnDeclaration<'ast>: Debug {
 pub trait FnParam<'ast>: Debug {
     fn get_pattern(&self) -> &dyn Pattern<'ast>;
 
-    fn get_span(&self) -> &dyn SpanOld<'ast>;
+    fn get_span(&self) -> &Span<'ast>;
 
     fn get_ty(&self) -> &dyn Ty<'ast>;
 }
@@ -284,7 +284,7 @@ pub trait AdtField<'ast>: Debug {
     fn get_attributes(&'ast self) -> &'ast dyn Attribute;
 
     /// This will return the span of the field, exclusing the field attributes.
-    fn get_span(&'ast self) -> &'ast dyn SpanOld<'ast>;
+    fn get_span(&'ast self) -> &'ast Span<'ast>;
 
     fn get_visibility(&'ast self) -> Visibility<'ast>;
 
@@ -465,7 +465,7 @@ pub trait GenericParam<'ast>: Debug {
     fn get_id(&self) -> GenericParamId;
 
     /// This returns the span of generic identifier.
-    fn get_span(&self) -> &'ast dyn SpanOld<'ast>;
+    fn get_span(&self) -> &'ast Span<'ast>;
 
     /// This returns the name of the generic, this can return `None` for unnamed
     /// or implicit generics. For lifetimes this will include the leading apostrophe.

--- a/linter_api/src/ast/item/use_decl_item.rs
+++ b/linter_api/src/ast/item/use_decl_item.rs
@@ -1,4 +1,4 @@
-use crate::ast::Path;
+use crate::ast::ItemPath;
 
 use super::{CommonItemData, UseKind};
 
@@ -23,7 +23,7 @@ use super::{CommonItemData, UseKind};
 #[derive(Debug)]
 pub struct UseDeclItem<'ast> {
     data: CommonItemData<'ast>,
-    use_path: Path<'ast>,
+    use_path: ItemPath<'ast>,
     use_kind: UseKind,
 }
 
@@ -32,7 +32,7 @@ super::impl_item_data!(UseDeclItem, UseDecl);
 impl<'ast> UseDeclItem<'ast> {
     /// Returns the path of this `use` item. For blob imports the `*` will
     /// be included in the simple path.
-    pub fn get_use_path(&self) -> &Path<'ast> {
+    pub fn get_use_path(&self) -> &ItemPath<'ast> {
         &self.use_path
     }
 
@@ -43,7 +43,7 @@ impl<'ast> UseDeclItem<'ast> {
 
 #[cfg(feature = "driver-api")]
 impl<'ast> UseDeclItem<'ast> {
-    pub fn new(data: CommonItemData<'ast>, use_path: Path<'ast>, use_kind: UseKind) -> Self {
+    pub fn new(data: CommonItemData<'ast>, use_path: ItemPath<'ast>, use_kind: UseKind) -> Self {
         Self {
             data,
             use_path,

--- a/linter_api/src/context.rs
+++ b/linter_api/src/context.rs
@@ -73,10 +73,10 @@ struct DriverCallbacks<'ast> {
     /// unknown to the api and adapter. The context has to be casted into the
     /// driver-specific type by the driver. A driver is always guaranteed to
     /// get its own context.
-    pub driver_context: *const (),
-    pub emit_lint: extern "C" fn(*const (), &'static Lint, &str, &Span<'ast>),
-    pub get_span: extern "C" fn(*const (), &SpanOwner) -> &'ast Span<'ast>,
-    pub span_snippet: extern "C" fn(*const (), &Span) -> Option<&'ast str>,
+    pub driver_context: &'ast (),
+    pub emit_lint: extern "C" fn(&'ast (), &'static Lint, &str, &Span<'ast>),
+    pub get_span: extern "C" fn(&'ast (), &SpanOwner) -> &'ast Span<'ast>,
+    pub span_snippet: extern "C" fn(&'ast (), &Span) -> Option<&'ast str>,
 }
 
 impl<'ast> DriverCallbacks<'ast> {

--- a/linter_api/src/context.rs
+++ b/linter_api/src/context.rs
@@ -1,45 +1,63 @@
-use crate::{
-    ast::{Span, Symbol},
-    lint::Lint,
-};
+use crate::{ast::Span, lint::Lint};
 
 /// This context will be passed to each [`super::LintPass`] call to enable the user
 /// to emit lints and to retieve nodes by the given ids.
 pub struct AstContext<'ast> {
-    cx: &'ast dyn DriverContext<'ast>,
+    driver: &'ast DriverCallbacks<'ast>,
 }
 
 #[cfg(feature = "driver-api")]
 impl<'ast> AstContext<'ast> {
-    pub fn new(cx: &'ast dyn DriverContext<'ast>) -> Self {
-        Self { cx }
+    pub fn new(driver: &'ast DriverCallbacks<'ast>) -> Self {
+        Self { driver }
     }
 }
 
 impl<'ast> AstContext<'ast> {
-    pub fn emit_lint(&self, s: &str, lint: &'ast Lint) {
-        self.cx.emit_lint(s, lint);
+    pub fn emit_lint(&self, msg: &str, lint: &'static Lint) {
+        self.driver.call_emit_lint_without_span(lint, msg)
     }
 
-    pub fn emit_lint_span(&self, s: &str, lint: &'ast Lint, sp: &dyn Span<'_>) {
-        self.cx.emit_lint_span(s, lint, sp);
+    pub fn emit_lint_span(&self, msg: &str, lint: &'static Lint, span: &dyn Span<'ast>) {
+        self.driver.call_emit_lint(lint, msg, span)
     }
 }
 
-/// This trait provides the actual implementation of [`AstContext`]. [`AstContext`] is just
-/// a wrapper type to avoid writing `dyn` for every context and to prevent users from
-/// implementing this trait.
-pub trait DriverContext<'ast> {
-    fn emit_lint(&self, s: &str, lint: &'ast Lint);
-    fn emit_lint_span(&self, s: &str, lint: &'ast Lint, sp: &dyn Span<'_>);
+#[repr(C)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+struct DriverCallbacks<'ast> {
+    /// This is a pointer to the driver context, provided to each function as
+    /// the first argument. This is an untyped pointer, since the driver is
+    /// unknown to the api and adapter. The context has to be casted into the
+    /// driver-specific type by the driver. A driver is always guaranteed to
+    /// get its own context.
+    driver_context: *const (),
+    pub emit_lint: extern "C" fn(*const (), &'static Lint, &str, &dyn Span<'ast>),
+    pub emit_lint_without_span: extern "C" fn(*const (), &'static Lint, &str),
 }
 
-/// This trait is used to create [`Symbol`]s and to turn them back into
-/// strings. It might be better to have a single struct like rustc does
-/// but I'm not sure how to properly implement this across crate bounderies.
-/// Having this trait seams clean enough for now.
-pub trait SymbolStore {
-    fn to_sym(&mut self, string: &str) -> Symbol;
+impl<'ast> DriverCallbacks<'ast> {
+    pub fn new(driver_context: *const ()) -> Self {
+        DriverCallbacks {
+            driver_context,
+            emit_lint: dummy_emit_lint,
+            emit_lint_without_span: dummy_emit_lint_without_span,
+        }
+    }
+}
 
-    fn sym_to_str(&self, sym: Symbol) -> &str;
+extern "C" fn dummy_emit_lint<'ast>(_data: *const (), _lint: &'static Lint, _msg: &str, _span: &dyn Span<'ast>) {
+    unimplemented!()
+}
+extern "C" fn dummy_emit_lint_without_span(_data: *const (), _lint: &'static Lint, _msg: &str) {
+    unimplemented!()
+}
+
+impl<'ast> DriverCallbacks<'ast> {
+    fn call_emit_lint(&self, lint: &'static Lint, msg: &str, span: &dyn Span<'ast>) {
+        (self.emit_lint)(self.driver_context, lint, msg, span)
+    }
+    fn call_emit_lint_without_span(&self, lint: &'static Lint, msg: &str) {
+        (self.emit_lint_without_span)(self.driver_context, lint, msg)
+    }
 }

--- a/linter_api/src/context.rs
+++ b/linter_api/src/context.rs
@@ -2,6 +2,7 @@ use crate::{ast::Span, lint::Lint};
 
 /// This context will be passed to each [`super::LintPass`] call to enable the user
 /// to emit lints and to retieve nodes by the given ids.
+#[repr(C)]
 pub struct AstContext<'ast> {
     driver: &'ast DriverCallbacks<'ast>,
 }
@@ -14,16 +15,38 @@ impl<'ast> AstContext<'ast> {
 }
 
 impl<'ast> AstContext<'ast> {
-    pub fn emit_lint(&self, msg: &str, lint: &'static Lint) {
-        self.driver.call_emit_lint_without_span(lint, msg)
-    }
-
-    pub fn emit_lint_span(&self, msg: &str, lint: &'static Lint, span: &dyn Span<'ast>) {
-        self.driver.call_emit_lint(lint, msg, span)
+    /// This function emits a lint at the current node with the given
+    /// message and span.
+    ///
+    /// For rustc the text output will look roughly to this:
+    /// ```txt
+    /// error: ducks can't talk
+    ///  --> $DIR/file.rs:17:5
+    ///    |
+    /// 17 |     println!("The duck said: 'Hello, World!'");
+    ///    |
+    /// ```
+    pub fn emit_lint(&self, lint: &'static Lint, msg: &str, span: &dyn Span<'ast>) {
+        self.driver.call_emit_lint(lint, msg, span);
     }
 }
 
+/// This struct holds function pointers to driver implementations of required
+/// functions. These can roughly be split into two categories:
+///
+/// 1. **Public utility**: These functions will be exposed to lint-crates via
+///     an [`AstContext`] instance. Therefore, the function signature of these
+///     has to be stable, or at least be stable for [`AstContext`].
+/// 2. **Internal utility**: These functions are intended for internal usage
+///     inside the API or the `linter_adapter` crate. Some nodes might also have
+///     a reference to these callbacks to request additional information if
+///     required. These are not part of the stable API and can therefore be changed.
+///
+/// Any changes to this struct will most likely require changes to the
+/// `DriverContextWrapper` implementation in the `liner_adapter` crate. That
+/// type provides a simple wrapper to avoid driver unrelated boilerplate code.
 #[repr(C)]
+#[doc(hidden)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
 struct DriverCallbacks<'ast> {
     /// This is a pointer to the driver context, provided to each function as
@@ -31,33 +54,12 @@ struct DriverCallbacks<'ast> {
     /// unknown to the api and adapter. The context has to be casted into the
     /// driver-specific type by the driver. A driver is always guaranteed to
     /// get its own context.
-    driver_context: *const (),
+    pub driver_context: *const (),
     pub emit_lint: extern "C" fn(*const (), &'static Lint, &str, &dyn Span<'ast>),
-    pub emit_lint_without_span: extern "C" fn(*const (), &'static Lint, &str),
-}
-
-impl<'ast> DriverCallbacks<'ast> {
-    pub fn new(driver_context: *const ()) -> Self {
-        DriverCallbacks {
-            driver_context,
-            emit_lint: dummy_emit_lint,
-            emit_lint_without_span: dummy_emit_lint_without_span,
-        }
-    }
-}
-
-extern "C" fn dummy_emit_lint<'ast>(_data: *const (), _lint: &'static Lint, _msg: &str, _span: &dyn Span<'ast>) {
-    unimplemented!()
-}
-extern "C" fn dummy_emit_lint_without_span(_data: *const (), _lint: &'static Lint, _msg: &str) {
-    unimplemented!()
 }
 
 impl<'ast> DriverCallbacks<'ast> {
     fn call_emit_lint(&self, lint: &'static Lint, msg: &str, span: &dyn Span<'ast>) {
-        (self.emit_lint)(self.driver_context, lint, msg, span)
-    }
-    fn call_emit_lint_without_span(&self, lint: &'static Lint, msg: &str) {
-        (self.emit_lint_without_span)(self.driver_context, lint, msg)
+        (self.emit_lint)(self.driver_context, lint, msg, span);
     }
 }

--- a/linter_api/src/ffi.rs
+++ b/linter_api/src/ffi.rs
@@ -1,0 +1,74 @@
+//! This module will hold types used for communication over FFI boundaries.
+//!
+//! There are some existing libraries and structures, like [`std::ffi`], which
+//! provide similar functionality. These tend to focus on creating a stable
+//! representation for calling C code, while we can expect both sides of the
+//! FFI interface is written in Rust. These representations will therefore
+//! focus on ABI safety, conversion, and simplicity by expecting that both
+//! sides use these types.
+//!
+//! All of these types are naturally not part of the stable API
+
+use std::{marker::PhantomData, slice};
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Str<'a> {
+    _lifetime: PhantomData<&'a ()>,
+    data: *const u8,
+    len: usize,
+}
+
+impl<'a> From<&'a str> for Str<'a> {
+    fn from(source: &'a str) -> Self {
+        Self {
+            _lifetime: PhantomData,
+            data: source.as_ptr(),
+            len: source.len(),
+        }
+    }
+}
+
+impl<'a> From<&Str<'a>> for &str {
+    fn from(src: &Str<'a>) -> Self {
+        unsafe {
+            let data = slice::from_raw_parts(src.data, src.len);
+
+            std::str::from_utf8_unchecked(data)
+        }
+    }
+}
+
+impl<'a> ToString for Str<'a> {
+    fn to_string(&self) -> String {
+        let base: &str = self.into();
+        base.to_string()
+    }
+}
+
+/// This is an FFI save option. In most cases it's better to pass a pointer and
+/// then use `as_ref()` but this doesn't work for owned return values.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum FfiOption<T> {
+    Some(T),
+    None,
+}
+
+impl<T> From<FfiOption<T>> for Option<T> {
+    fn from(src: FfiOption<T>) -> Self {
+        match src {
+            FfiOption::Some(t) => Option::Some(t),
+            FfiOption::None => Option::None,
+        }
+    }
+}
+
+impl<T> From<Option<T>> for FfiOption<T> {
+    fn from(src: Option<T>) -> Self {
+        match src {
+            Option::Some(t) => FfiOption::Some(t),
+            Option::None => FfiOption::None,
+        }
+    }
+}

--- a/linter_api/src/lib.rs
+++ b/linter_api/src/lib.rs
@@ -11,6 +11,9 @@ pub mod context;
 pub mod interface;
 pub mod lint;
 
+#[doc(hidden)]
+pub mod ffi;
+
 /// **!Unstable!**
 ///
 /// This macro returns a list of all functions declared for the [`LintPass`] trait.

--- a/linter_api/src/lib.rs
+++ b/linter_api/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(clippy::pedantic)]
-#![warn(clippy::index_refutable_slice)]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/linter_driver_rustc/src/ast/common.rs
+++ b/linter_driver_rustc/src/ast/common.rs
@@ -1,10 +1,13 @@
 #![allow(unused_variables)]
 
-use std::fmt::Debug;
+use std::{fmt::Debug, mem::transmute};
 
-use linter_api::ast::{Attribute, BodyId, CrateId, Lifetime, Path, PathResolution, PathSegment, Span, Symbol};
+use linter_api::ast::{
+    Attribute, BodyId, CrateId, ItemPath, Lifetime, PathResolution, PathSegment, Span, SpanId, SpanOld, SpanSource, Symbol,
+};
 
 use super::{rustc::RustcContext, ToApi};
+use rustc_lint::LintContext;
 
 impl<'ast, 'tcx> ToApi<'ast, 'tcx, CrateId> for rustc_hir::def_id::CrateNum {
     fn to_api(&self, _cx: &'ast RustcContext<'ast, 'tcx>) -> CrateId {
@@ -17,6 +20,31 @@ impl<'ast, 'tcx> ToApi<'ast, 'tcx, BodyId> for rustc_hir::BodyId {
         let (x1, x2) = self.hir_id.index();
         BodyId::new(x1, x2)
     }
+}
+
+#[expect(clippy::missing_panics_doc)]
+pub fn api_span_from_rustc_span<'ast, 'tcx>(
+    cx: &'ast RustcContext<'ast, 'tcx>,
+    span: rustc_span::Span,
+) -> &'ast Span<'ast> {
+    // FIXME: Calling this code "hacky" would be an understatement... Cleaning
+    // this code up is sadly not that easy and requires a restructuring of
+    // this driver. This is high on the TODO list. Actually, the next thing after
+    // a rustc sync but sadly after reworking the lint-crate -> driver
+    // communication. Therefore, I'm adding/leaving this hack as my next TODO to
+    // make progress on the other front.
+
+    let rustc_data = span.data();
+    let span_file = cx.rustc_cx.sess().source_map().lookup_source_file(span.lo());
+    if let rustc_span::FileName::Real(path) = &span_file.name {
+        let thing = path.clone().into_local_path().as_ref().map(std::clone::Clone::clone).unwrap();
+        let thing = cx.alloc_with(move || thing);
+        let source = SpanSource::File(thing);
+        let start = span.lo() - span_file.start_pos;
+        let end = span.hi() - span_file.start_pos;
+        return cx.alloc_with(|| Span::new(cx.ast_cx(), source, start.0 as usize, end.0 as usize));
+    }
+    unimplemented!()
 }
 
 #[derive(Debug)]
@@ -32,13 +60,13 @@ impl<'ast, 'tcx> RustcSpan<'ast, 'tcx> {
     }
 }
 
-impl<'ast, 'tcx> ToApi<'ast, 'tcx, &'ast dyn Span<'ast>> for rustc_span::Span {
-    fn to_api(&self, cx: &'ast RustcContext<'ast, 'tcx>) -> &'ast dyn Span<'ast> {
+impl<'ast, 'tcx> ToApi<'ast, 'tcx, &'ast dyn SpanOld<'ast>> for rustc_span::Span {
+    fn to_api(&self, cx: &'ast RustcContext<'ast, 'tcx>) -> &'ast dyn SpanOld<'ast> {
         cx.alloc_with(|| RustcSpan::new(*self, cx))
     }
 }
 
-impl<'ast, 'tcx> linter_api::ast::Span<'ast> for RustcSpan<'ast, 'tcx> {
+impl<'ast, 'tcx> linter_api::ast::SpanOld<'ast> for RustcSpan<'ast, 'tcx> {
     fn is_from_expansion(&self) -> bool {
         self.span.from_expansion()
     }
@@ -47,11 +75,11 @@ impl<'ast, 'tcx> linter_api::ast::Span<'ast> for RustcSpan<'ast, 'tcx> {
         self.span.in_derive_expansion()
     }
 
-    fn contains(&self, other: &dyn linter_api::ast::Span<'ast>) -> bool {
+    fn contains(&self, other: &dyn linter_api::ast::SpanOld<'ast>) -> bool {
         todo!()
     }
 
-    fn overlaps(&self, other: &dyn linter_api::ast::Span<'ast>) -> bool {
+    fn overlaps(&self, other: &dyn linter_api::ast::SpanOld<'ast>) -> bool {
         todo!()
     }
 
@@ -59,15 +87,15 @@ impl<'ast, 'tcx> linter_api::ast::Span<'ast> for RustcSpan<'ast, 'tcx> {
         todo!()
     }
 
-    fn to(&'ast self, end: &dyn linter_api::ast::Span<'ast>) -> &dyn linter_api::ast::Span<'ast> {
+    fn to(&'ast self, end: &dyn linter_api::ast::SpanOld<'ast>) -> &dyn linter_api::ast::SpanOld<'ast> {
         todo!()
     }
 
-    fn between(&'ast self, end: &dyn linter_api::ast::Span<'ast>) -> &dyn linter_api::ast::Span<'ast> {
+    fn between(&'ast self, end: &dyn linter_api::ast::SpanOld<'ast>) -> &dyn linter_api::ast::SpanOld<'ast> {
         todo!()
     }
 
-    fn until(&'ast self, end: &dyn linter_api::ast::Span<'ast>) -> &dyn linter_api::ast::Span<'ast> {
+    fn until(&'ast self, end: &dyn linter_api::ast::SpanOld<'ast>) -> &dyn linter_api::ast::SpanOld<'ast> {
         todo!()
     }
 
@@ -80,13 +108,53 @@ impl<'ast, 'tcx> linter_api::ast::Span<'ast> for RustcSpan<'ast, 'tcx> {
     }
 }
 
+#[must_use] pub fn rustc_span_from_span_id(span_id: SpanId) -> rustc_span::Span {
+    // # Safety
+    //
+    // [`SpanId`]s are only created by [`span_id_from_rustc_span`] which uses
+    // the same transmute. The size of these structs are validated in an extra
+    // check.
+    //
+    // FIXME: In theory this is still unsound since [`rustc_span::Span`] doesn't
+    // have `[repr(C)]`. For a stable release this should be fixed. Until then this
+    // is as simple and safe as it gets.
+    unsafe { transmute::<SpanId, rustc_span::Span>(span_id) }
+}
+
+#[must_use] pub fn span_id_from_rustc_span(rustc_span: rustc_span::Span) -> SpanId {
+    // # Safety
+    //
+    // The here created [`SpanId`]s are transformed back by [`rustc_span_from_span_id`]
+    // which uses the same transmute. The size of these structs are validated in an extra
+    // test.
+    unsafe { transmute::<rustc_span::Span, SpanId>(rustc_span) }
+}
+
+#[cfg(test)]
+mod tests {
+use std::mem::size_of;
+
+/// These tests validate that the size of transmutation sources and targets
+/// doesn't change unexpected. If a size is changed all transmutational usages
+/// will need to be checked.
+#[test]
+pub fn check_transmute_target_sizes() {
+    assert_eq!(size_of::<rustc_span::Span>(), 8, "Test `rustc_span::Span`");
+    assert_eq!(
+        size_of::<linter_api::ast::SpanId>(),
+        8,
+        "Test `linter_api::ast::SpanId`"
+    );
+}
+}
+
 pub fn path_from_rustc<'ast, 'tcx>(
     cx: &'ast RustcContext<'ast, 'tcx>,
     inner: &'tcx rustc_hir::Path<'tcx>,
-) -> Path<'ast> {
+) -> ItemPath<'ast> {
     let target = inner.res.to_api(cx);
     let segments = cx.alloc_slice_from_iter(inner.segments.iter().map(|seg| seg.to_api(cx)));
-    Path::new(segments, target)
+    ItemPath::new(segments, target)
 }
 
 impl<'ast, 'tcx> ToApi<'ast, 'tcx, PathSegment> for rustc_hir::PathSegment<'tcx> {

--- a/linter_driver_rustc/src/ast/item.rs
+++ b/linter_driver_rustc/src/ast/item.rs
@@ -35,6 +35,7 @@ pub fn rustc_crate_id_from_api_create_id(api_id: CrateId) -> rustc_hir::def_id::
 
 #[cfg(test)]
 pub mod test {
+    #[allow(clippy::missing_panics_doc)]
     #[test]
     pub fn test_magic_sizes() {
         assert_eq!(std::mem::size_of::<rustc_hir::def_id::DefIndex>(), 4);

--- a/linter_driver_rustc/src/ast/item.rs
+++ b/linter_driver_rustc/src/ast/item.rs
@@ -19,7 +19,8 @@ impl<'ast, 'tcx> ToApi<'ast, 'tcx, ItemId> for rustc_hir::def_id::DefId {
     }
 }
 
-#[must_use] pub fn rustc_item_id_from_api_item_id(api_id: ItemId) -> rustc_hir::def_id::DefId {
+#[must_use]
+pub fn rustc_item_id_from_api_item_id(api_id: ItemId) -> rustc_hir::def_id::DefId {
     let (krate, index) = api_id.get_data();
     rustc_hir::def_id::DefId {
         index: unsafe { std::mem::transmute::<u32, rustc_hir::def_id::DefIndex>(index) },
@@ -27,7 +28,8 @@ impl<'ast, 'tcx> ToApi<'ast, 'tcx, ItemId> for rustc_hir::def_id::DefId {
     }
 }
 
-#[must_use] pub fn rustc_crate_id_from_api_create_id(api_id: CrateId) -> rustc_hir::def_id::CrateNum {
+#[must_use]
+pub fn rustc_crate_id_from_api_create_id(api_id: CrateId) -> rustc_hir::def_id::CrateNum {
     unsafe { transmute::<CrateId, rustc_hir::def_id::CrateNum>(api_id) }
 }
 

--- a/linter_driver_rustc/src/ast/item.rs
+++ b/linter_driver_rustc/src/ast/item.rs
@@ -11,11 +11,33 @@ use linter_api::ast::{
 use super::{path_from_rustc, rustc::RustcContext};
 use crate::ast::ToApi;
 
-use std::fmt::Debug;
+use std::{fmt::Debug, mem::transmute};
 
 impl<'ast, 'tcx> ToApi<'ast, 'tcx, ItemId> for rustc_hir::def_id::DefId {
     fn to_api(&self, cx: &'ast RustcContext<'ast, 'tcx>) -> ItemId {
         ItemId::new(self.krate.to_api(cx), self.index.as_u32())
+    }
+}
+
+#[must_use] pub fn rustc_item_id_from_api_item_id(api_id: ItemId) -> rustc_hir::def_id::DefId {
+    let (krate, index) = api_id.get_data();
+    rustc_hir::def_id::DefId {
+        index: unsafe { std::mem::transmute::<u32, rustc_hir::def_id::DefIndex>(index) },
+        krate: rustc_crate_id_from_api_create_id(krate),
+    }
+}
+
+#[must_use] pub fn rustc_crate_id_from_api_create_id(api_id: CrateId) -> rustc_hir::def_id::CrateNum {
+    unsafe { transmute::<CrateId, rustc_hir::def_id::CrateNum>(api_id) }
+}
+
+#[cfg(test)]
+pub mod test {
+    #[test]
+    pub fn test_magic_sizes() {
+        assert_eq!(std::mem::size_of::<rustc_hir::def_id::DefIndex>(), 4);
+        assert_eq!(std::mem::size_of::<rustc_hir::def_id::CrateNum>(), 4);
+        assert_eq!(std::mem::size_of::<linter_api::ast::CrateId>(), 4);
     }
 }
 
@@ -75,8 +97,8 @@ fn create_common_data<'ast, 'tcx>(
     rustc_item: &'tcx rustc_hir::Item<'tcx>,
 ) -> CommonItemData<'ast> {
     CommonItemData::new(
+        cx.ast_cx(),
         rustc_item.def_id.to_def_id().to_api(cx),
-        rustc_item.span.to_api(cx),
         vis_from_rustc(cx, rustc_item),
         (!rustc_item.ident.name.is_empty()).then(|| rustc_item.ident.name.to_api(cx)),
     )

--- a/linter_driver_rustc/src/ast/rustc.rs
+++ b/linter_driver_rustc/src/ast/rustc.rs
@@ -7,14 +7,14 @@ use rustc_lint::{LateContext, Level as RustcLevel, Lint as RustcLint, LintContex
 use linter_api::{
     ast::{
         ty::{Ty, TyKind},
-        Ident, Lifetime, Span, SpanOld, SpanOwner, SpanSource, Symbol,
+        Lifetime, Span, SpanOwner, SpanSource, Symbol,
     },
     context::AstContext,
     lint::{Level, Lint, MacroReport},
 };
 use rustc_span::BytePos;
 
-use super::{api_span_from_rustc_span, item::rustc_item_id_from_api_item_id, ty::RustcTy, RustcLifetime, RustcSpan};
+use super::{api_span_from_rustc_span, item::rustc_item_id_from_api_item_id, ty::RustcTy, RustcLifetime};
 
 pub struct RustcContext<'ast, 'tcx> {
     pub(crate) ast_cx: OnceCell<&'ast AstContext<'ast>>,
@@ -162,20 +162,9 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
 
 impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
     #[must_use]
-    pub fn new_span(&'ast self, span: rustc_span::Span) -> &'ast dyn SpanOld<'ast> {
-        self.buffer.alloc_with(|| RustcSpan::new(span, self))
-    }
-
-    #[must_use]
     #[allow(clippy::unused_self)]
     pub fn new_symbol(&'ast self, sym: rustc_span::symbol::Symbol) -> Symbol {
         Symbol::new(sym.as_u32())
-    }
-
-    #[must_use]
-    pub fn new_ident(&'ast self, ident: rustc_span::symbol::Ident) -> &'ast Ident<'ast> {
-        self.buffer
-            .alloc_with(|| Ident::new(self.new_symbol(ident.name), self.new_span(ident.span)))
     }
 
     #[must_use]

--- a/linter_driver_rustc/src/ast/rustc.rs
+++ b/linter_driver_rustc/src/ast/rustc.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{OnceCell, RefCell};
 
 use linter_adapter::context::DriverContext;
 use rustc_data_structures::fx::FxHashMap;
@@ -7,16 +7,20 @@ use rustc_lint::{LateContext, Level as RustcLevel, Lint as RustcLint, LintContex
 use linter_api::{
     ast::{
         ty::{Ty, TyKind},
-        Ident, Lifetime, Span, Symbol,
+        Ident, Lifetime, Span, SpanOld, SpanOwner, SpanSource, Symbol,
     },
+    context::AstContext,
     lint::{Level, Lint, MacroReport},
 };
+use rustc_span::BytePos;
 
-use super::{ty::RustcTy, RustcLifetime, RustcSpan};
+use super::{api_span_from_rustc_span, item::rustc_item_id_from_api_item_id, ty::RustcTy, RustcLifetime, RustcSpan};
 
 pub struct RustcContext<'ast, 'tcx> {
+    pub(crate) ast_cx: OnceCell<&'ast AstContext<'ast>>,
     pub(crate) rustc_cx: &'ast LateContext<'tcx>,
     pub(crate) lint_map: RefCell<FxHashMap<&'ast Lint, &'static RustcLint>>,
+    pub(crate) span_source_map: RefCell<FxHashMap<SpanSource<'ast>, (BytePos, rustc_span::hygiene::SyntaxContext)>>,
     /// All items should be created using the `alloc_*` functions. This ensures
     /// that we can later change the way we allocate and manage our memory
     buffer: &'ast bumpalo::Bump,
@@ -58,29 +62,69 @@ fn to_leaked_rustc_lint<'ast>(
 }
 
 impl<'ast, 'tcx> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
-    fn emit_lint(&self, lint: &'static Lint, msg: &str, span: &dyn Span<'ast>) {
-        // Safety:
-        //
-        // Clearly this is probably not ideal but I did find this (answered by people much more
-        // knowledgeable about lifetime/unsafe/transmute)
-        // https://users.rust-lang.org/t/solved-transmute-between-trait-objects/13995/6
-        //
-        // In regard to the leak/forget, since we can keep this within the `'tcx` - `'ast` lifetime I don't
-        // think we have to. We aren't returning a `dyn Trait + 'static` like if we were actually using the
-        // `dyn Any` or the `dyn Span<'_>`. We can't use the `Any::downcast_ref` machinery here since we
-        // have a non `'static` trait object in `Span` (at least I couldn't get it to work)
-        #[allow(clippy::ptr_as_ptr, clippy::cast_ptr_alignment)]
-        let down_span: &RustcSpan<'ast, 'tcx> = unsafe {
-            let sp_ptr = span as *const _ as *const (*mut (), *mut ());
-            &*(sp_ptr as *const dyn std::any::Any as *const _)
-        };
+    fn emit_lint(&self, lint: &'static Lint, msg: &str, span: &Span<'ast>) {
+        let (in_file_pos, rustc_ctxt) = self
+            .span_source_map
+            .borrow()
+            .get(&span.source())
+            .map(|&(p, c)| (p, c))
+            .unwrap();
+        let rustc_file = self.rustc_cx.sess().source_map().lookup_source_file(in_file_pos);
+        #[expect(clippy::cast_possible_truncation)]
+        let lo = BytePos(span.start() as u32) + rustc_file.start_pos;
+        #[expect(clippy::cast_possible_truncation)]
+        let hi = BytePos(span.end() as u32) + rustc_file.start_pos;
+        let span = rustc_span::DUMMY_SP.with_ctxt(rustc_ctxt).with_lo(lo).with_hi(hi);
 
         let mut map = self.lint_map.borrow_mut();
         self.rustc_cx
-            .struct_span_lint(to_leaked_rustc_lint(&mut *map, lint), down_span.span, |diag| {
+            .struct_span_lint(to_leaked_rustc_lint(&mut *map, lint), span, |diag| {
                 let mut diag = diag.build(msg);
                 diag.emit();
             });
+    }
+
+    fn get_span(&'ast self, owner: &SpanOwner) -> &'ast Span<'ast> {
+        match &owner {
+            // FIXME use `api_span_from_rustc_span`
+            SpanOwner::Item(api_id) => {
+                let rustc_def_id = rustc_item_id_from_api_item_id(*api_id);
+                let rustc_item_id = rustc_hir::ItemId {
+                    def_id: rustc_hir::def_id::LocalDefId {
+                        local_def_index: rustc_def_id.index,
+                    },
+                };
+                let item = self.rustc_cx.tcx.hir().item(rustc_item_id);
+                let api_span = self.alloc_with(|| api_span_from_rustc_span(self, item.span));
+
+                let mut map = self.span_source_map.borrow_mut();
+                map.entry(api_span.source())
+                    .or_insert((item.span.lo(), item.span.data().ctxt));
+
+                api_span
+            }, //
+            SpanOwner::Body(_) => todo!(),
+            SpanOwner::SpecificSpan(_span_id) => todo!(),
+        }
+    }
+
+    fn span_snippet(&self, span: &linter_api::ast::Span) -> Option<&'ast str> {
+        match span.source() {
+            linter_api::ast::SpanSource::File(path) => {
+                let name = rustc_span::FileName::Real(rustc_span::RealFileName::LocalPath(path.clone()));
+                let file = self.rustc_cx.sess().source_map().get_source_file(&name)?;
+                let src = file
+                    .as_ref()
+                    .src
+                    .as_ref()
+                    .and_then(|src| src.get(span.start()..span.end()));
+                Some(self.buffer.alloc_str(src?))
+                // let text = file_src.get(span.start()..span.end())?;
+                // let src = self.alloc_with(|| text.to_string());
+                // Some(src.as)
+            },
+            linter_api::ast::SpanSource::Macro(_) => todo!(),
+        }
     }
 }
 
@@ -108,11 +152,17 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
     {
         self.buffer.alloc_slice_fill_with(len, f)
     }
+
+    pub fn ast_cx(&self) -> &AstContext<'ast> {
+        self.ast_cx
+            .get()
+            .expect("directly set after creation and should therefore be valid")
+    }
 }
 
 impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
     #[must_use]
-    pub fn new_span(&'ast self, span: rustc_span::Span) -> &'ast dyn Span<'ast> {
+    pub fn new_span(&'ast self, span: rustc_span::Span) -> &'ast dyn SpanOld<'ast> {
         self.buffer.alloc_with(|| RustcSpan::new(span, self))
     }
 
@@ -142,8 +192,10 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
     #[must_use]
     pub fn new(ctx: &'ast LateContext<'tcx>, buffer: &'ast bumpalo::Bump) -> Self {
         Self {
+            ast_cx: OnceCell::new(),
             rustc_cx: ctx,
             lint_map: RefCell::default(),
+            span_source_map: RefCell::default(),
             buffer,
         }
     }

--- a/linter_driver_rustc/src/conversion.rs
+++ b/linter_driver_rustc/src/conversion.rs
@@ -42,6 +42,7 @@ fn process_items<'tcx>(rustc_cx: &LateContext<'tcx>, allocator: &mut Bump) {
     let callbacks_wrapper = allocator.alloc_with(|| DriverContextWrapper::new(driver_cx));
     let callbacks = allocator.alloc_with(|| callbacks_wrapper.create_driver_callback());
     let ast_cx = driver_cx.alloc_with(|| AstContext::new(callbacks));
+    let _ = driver_cx.ast_cx.set(ast_cx);
 
     let map = rustc_cx.tcx.hir();
     // Here we need to collect the items to have a knwon size for the allocation

--- a/linter_driver_rustc/src/main.rs
+++ b/linter_driver_rustc/src/main.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![feature(rustc_private)]
 #![feature(lint_reasons)]
+#![feature(once_cell)]
 #![warn(rustc::internal)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::index_refutable_slice)]

--- a/linter_lints/src/lib.rs
+++ b/linter_lints/src/lib.rs
@@ -21,6 +21,6 @@ impl<'ast> LintPass<'ast> for TestLintPass {
     }
 
     fn check_static_item(&mut self, cx: &'ast AstContext<'ast>, item: &'ast StaticItem<'ast>) {
-        cx.emit_lint_span("hey there is a static item here", TEST_LINT, item.get_span());
+        cx.emit_lint(TEST_LINT, "hey there is a static item here", item.get_span());
     }
 }

--- a/linter_lints/tests/ui/find_static.stderr
+++ b/linter_lints/tests/ui/find_static.stderr
@@ -1,8 +1,9 @@
 warning: hey there is a static item here
- --> $DIR/find_static.rs:2:1
+ --> $DIR/find_static.rs:1:1
   |
-2 | static TEST: u32 = 4;
-  | ^^^^^^^^^^^^^^^^^^^^^
+1 | /
+2 | | static TEST: u32 = 4;
+  | |_____________________^
   |
   = note: `#[warn(linter::test_lint)]` on by default
 


### PR DESCRIPTION
This PR reworks the *lint-crate/linter_api -> driver* communication to be ABI safe. The previous implementation was using a lot of undefined behavior. An unstable ABI is fun... though I understand why rustc does this.

The basic idea is as follows:
* Driver callbacks are provided as `extern "C"` functions which can safely be called.
* All data send over these calls is FFI safe
* Some conversion magic and FFI safety is done by `linter_api` and `linter_adapter`, which allows drivers to only implement the `DriverContext` trait

### Open TODOs

* [ ] This PR and the previous one, assume that all ast types are FFI safe which they aren't. This communication therefore is not yet totally safe. However, the concept should be fine and seems to work well enough
* [ ] Clean up the rustc driver #35 
* [ ] Rework/Expand `Span`s to support macros and other edge cases

---

@HKalbasi This PR was the main blocker for adding a new driver. Once this is merged, you should be able to test ra as another driver. I would highly recommend not looking at the current rustc driver, but implement the ra-driver based on the api/adapter crate and your own experience. In the rustc-driver I've played around with several concepts and by now it's an unmaintainable mess which I'll clean up next.

Also note that most AST nodes need to be reworked to be FFI safe. For now, I would suggest only working with the `StaticItem` node which is the newest and cleanest one. The rework of other items will probably follow that example.

If you have the time, you can also review this PR and provide feedback on the interface :upside_down_face:. If nobody as reviewed it by the next PR, I'll merge this :)

---

CC: #8 
CC: #33