### PR TITLE
Add `TyId` and adjust `SymbolID` and `SpanId` visibility

### DIFF
--- a/cargo-linter/src/main.rs
+++ b/cargo-linter/src/main.rs
@@ -130,6 +130,7 @@ fn prepare_lint_crate(krate: &str, verbose: bool) -> Result<String, ()> {
             "--out-dir",
             &*LINT_KRATES_OUT_DIR,
         ])
+        .env("RUSTFLAGS", "--cap-lints=allow")
         .spawn()
         .expect("could not run cargo")
         .wait()
@@ -186,6 +187,7 @@ fn validate_driver(verbose: bool) {
 
         let exit_status = cmd
             .args(["build", "-p", "linter_driver_rustc"])
+            .env("RUSTFLAGS", "--cap-lints=allow")
             .spawn()
             .expect("could not run cargo")
             .wait()

--- a/linter_adapter/src/context.rs
+++ b/linter_adapter/src/context.rs
@@ -1,5 +1,5 @@
 use linter_api::{
-    ast::{Span, SpanOwner},
+    ast::{Span, SpanOwner, SymbolId},
     context::DriverCallbacks,
     ffi,
     lint::Lint,
@@ -34,6 +34,7 @@ impl<'ast> DriverContextWrapper<'ast> {
             emit_lint,
             get_span,
             span_snippet,
+            symbol_str,
         }
     }
 }
@@ -53,8 +54,14 @@ extern "C" fn span_snippet<'ast>(data: &(), span: &Span) -> ffi::FfiOption<ffi::
     wrapper.driver_cx.span_snippet(span).map(Into::into).into()
 }
 
+extern "C" fn symbol_str<'ast>(data: &(), sym: SymbolId) -> ffi::Str<'ast> {
+    let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
+    wrapper.driver_cx.symbol_str(sym).into()
+}
+
 pub trait DriverContext<'ast> {
     fn emit_lint(&'ast self, lint: &'static Lint, msg: &str, span: &Span<'ast>);
     fn get_span(&'ast self, owner: &SpanOwner) -> &'ast Span<'ast>;
     fn span_snippet(&'ast self, span: &Span) -> Option<&'ast str>;
+    fn symbol_str(&'ast self, sym: SymbolId) -> &'ast str;
 }

--- a/linter_api/src/ast/common/id.rs
+++ b/linter_api/src/ast/common/id.rs
@@ -49,7 +49,6 @@ impl ItemId {
     }
 }
 
-
 /// This ID uniquely identifies a type during linting, the id is not stable
 /// between different sessions.
 ///
@@ -57,7 +56,7 @@ impl ItemId {
 /// provide the current trait implementations.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TypeId {
+pub struct TyId {
     /// The layout of the data is up to the driver implementation. The API will never
     /// create custom IDs and pass them to the driver. The size of this type might
     /// change. Drivers should validate the size with tests.
@@ -65,7 +64,7 @@ pub struct TypeId {
 }
 
 #[cfg(feature = "driver-api")]
-impl TypeId {
+impl TyId {
     pub fn new(data: u64) -> Self {
         Self { data }
     }

--- a/linter_api/src/ast/common/id.rs
+++ b/linter_api/src/ast/common/id.rs
@@ -49,6 +49,32 @@ impl ItemId {
     }
 }
 
+
+/// This ID uniquely identifies a type during linting, the id is not stable
+/// between different sessions.
+///
+/// The layout and size of this type might change. The id will continue to
+/// provide the current trait implementations.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TypeId {
+    /// The layout of the data is up to the driver implementation. The API will never
+    /// create custom IDs and pass them to the driver. The size of this type might
+    /// change. Drivers should validate the size with tests.
+    data: u64,
+}
+
+#[cfg(feature = "driver-api")]
+impl TypeId {
+    pub fn new(data: u64) -> Self {
+        Self { data }
+    }
+
+    pub fn data(&self) -> u64 {
+        self.data
+    }
+}
+
 /// This ID uniquely identifies a body during linting, the id is not stable
 /// between different sessions.
 ///
@@ -84,7 +110,7 @@ impl BodyId {
 #[repr(C)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SpanId {
+pub(crate) struct SpanId {
     /// The layout of the data is up to the driver implementation. The API will never
     /// create custom IDs and pass them to the driver. The size of this type might
     /// change. Drivers should validate the size with tests.
@@ -110,9 +136,9 @@ impl SpanId {
 ///
 /// FIXME: Don't leak the type once the common data macro was fixed
 #[repr(C)]
-#[doc(hidden)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SymbolId {
+pub(crate) struct SymbolId {
     /// The layout of the data is up to the driver implementation. The API will never
     /// create custom IDs and pass them to the driver. The size of this type might
     /// change. Drivers should validate the size with tests.

--- a/linter_api/src/ast/item.rs
+++ b/linter_api/src/ast/item.rs
@@ -31,7 +31,7 @@ pub trait ItemData<'ast>: Debug {
     fn visibility(&self) -> &Visibility<'ast>;
 
     /// This function can return `None` if the item was generated and has no real name
-    fn name(&self) -> Option<SymbolId>;
+    fn name(&self) -> Option<String>;
 
     /// This returns this [`ItemData`] instance as a [`ItemType`]. This can be useful for
     /// functions that take [`ItemType`] as a parameter. For general function calls it's better
@@ -63,7 +63,7 @@ impl<'ast> ItemType<'ast> {
     impl_item_type_fn!(id() -> ItemId);
     impl_item_type_fn!(span() -> &'ast Span<'ast>);
     impl_item_type_fn!(visibility() -> &Visibility<'ast>);
-    impl_item_type_fn!(name() -> Option<SymbolId>);
+    impl_item_type_fn!(name() -> Option<String>);
     impl_item_type_fn!(attrs() -> ());
 }
 
@@ -112,8 +112,8 @@ macro_rules! impl_item_data {
                 &self.data.vis
             }
 
-            fn name(&self) -> Option<crate::ast::SymbolId> {
-                Some(self.data.name)
+            fn name(&self) -> Option<String> {
+                Some(self.data.cx.symbol_str(self.data.name))
             }
 
             fn as_item(&'ast self) -> crate::ast::item::ItemType<'ast> {

--- a/linter_api/src/ffi.rs
+++ b/linter_api/src/ffi.rs
@@ -29,7 +29,7 @@ impl<'a> From<&'a str> for Str<'a> {
     }
 }
 
-impl<'a> From<&Str<'a>> for &str {
+impl<'a> From<&Str<'a>> for &'a str {
     fn from(src: &Str<'a>) -> Self {
         unsafe {
             let data = slice::from_raw_parts(src.data, src.len);
@@ -70,5 +70,41 @@ impl<T> From<Option<T>> for FfiOption<T> {
             Option::Some(t) => FfiOption::Some(t),
             Option::None => FfiOption::None,
         }
+    }
+}
+
+#[repr(C)]
+pub struct FfiSlice<'a, T> {
+    _lifetime: PhantomData<&'a ()>,
+    data: *const T,
+    len: usize,
+}
+
+impl<'a, T> FfiSlice<'a, T> {
+    pub fn as_slice(&self) -> &'a [T] {
+        self.into()
+    }
+}
+
+impl<'a, T> From<&'a [T]> for FfiSlice<'a, T> {
+    fn from(src_data: &'a [T]) -> Self {
+        Self {
+            _lifetime: PhantomData,
+            data: src_data.as_ptr(),
+            len: src_data.len(),
+        }
+    }
+}
+
+impl<'a, T> From<&FfiSlice<'a, T>> for &'a [T] {
+    fn from(src: &FfiSlice<'a, T>) -> Self {
+        unsafe { slice::from_raw_parts(src.data, src.len) }
+    }
+}
+
+impl<'a, T: std::fmt::Debug> std::fmt::Debug for FfiSlice<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let data: &[T] = self.into();
+        f.debug_list().entries(data.iter()).finish()
     }
 }

--- a/linter_driver_rustc/src/context.rs
+++ b/linter_driver_rustc/src/context.rs
@@ -2,14 +2,16 @@ use std::cell::OnceCell;
 
 use linter_adapter::context::{DriverContext, DriverContextWrapper};
 use linter_api::{
-    ast::{Span, SpanOwner},
+    ast::{Span, SpanOwner, SymbolId},
     context::AstContext,
     lint::Lint,
 };
 use rustc_lint::LintStore;
 use rustc_middle::ty::TyCtxt;
 
-use crate::conversion::{to_api_span, to_rustc_item_id, to_rustc_lint, to_rustc_span, to_rustc_span_from_id};
+use crate::conversion::{
+    to_api_span, to_rustc_item_id, to_rustc_lint, to_rustc_span, to_rustc_span_from_id, to_rustc_symbol,
+};
 
 use self::storage::Storage;
 
@@ -83,5 +85,11 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
 
     fn span_snippet(&self, _span: &Span) -> Option<&'ast str> {
         todo!()
+    }
+
+    fn symbol_str(&'ast self, sym: SymbolId) -> &'ast str {
+        let sym = to_rustc_symbol(self, sym);
+        // Based on the comment of `rustc_span::Symbol::as_str` this should be fine.
+        unsafe { std::mem::transmute(sym.as_str()) }
     }
 }


### PR DESCRIPTION
I'm currently working on `Generics` which are tightly bound to types, traits, and items. I believe the next PR will be another monster. Therefore, I'm trying to extract some early commits like these :)